### PR TITLE
Update kanayago.patch

### DIFF
--- a/kanayago.patch
+++ b/kanayago.patch
@@ -50,7 +50,7 @@ index 267f619..841db65 100644
 +static VALUE
 +suppress_tracing(VALUE (*func)(VALUE), VALUE arg)
 +{
-+    return rb_suppress_tracing(func, arg);
++    return func(arg);
 +}
 +
 +static ID


### PR DESCRIPTION
When using Ruby head that not enabled Universal Parser caused undefined symbol error.
That caused by rb_suppress_tracing symbol not found in Kanayago build scope.
And, rb_suppress_tracing function was collback function that may function pointer.

So, fix to use function pointer in suppress_tracing function.