### PR TITLE
Fix RuboCop segv in ruby head

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.10.2)
+    json (2.11.3)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    zlib (3.1.1)
+    zlib (3.2.1)
 
 PLATFORMS
   ruby

--- a/test/kanayago/parse_while_node_test.rb
+++ b/test/kanayago/parse_while_node_test.rb
@@ -12,7 +12,7 @@ class ParseWhileNodeTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    result.body
     line = result.body.last
 
     assert_instance_of(Kanayago::WhileNode, line)


### PR DESCRIPTION
Caused by old `zlib` and `json` gem.