### PR TITLE
Fix some Segmentation Fault and Remove unneeded code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix segmentation fault when parsing dynamic symbols in complex hash structures
+- Fix segmentation fault when parsing nested modules with outer constant references
+- Fix `module_node_new` to use `RNODE_MODULE` instead of incorrect `RNODE_CLASS` macro
+- Add NULL pointer checks in `dynamic_string_node_new`, `dynamic_symbol_node_new`, `dynamic_execute_string_node_new`, and `dynamic_regexp_node_new`
+
+### Changed
+- Remove incorrect `@super` field access from `ModuleNode` (modules do not have superclasses)
+
 ## [0.4.0]
 
 ### Added

--- a/ext/kanayago/kanayago.c
+++ b/ext/kanayago/kanayago.c
@@ -193,9 +193,8 @@ module_node_new(const NODE *node)
 {
     VALUE obj = rb_class_new_instance(0, 0, rb_cModuleNode);
 
-    rb_ivar_set(obj, rb_intern("@cpath"), ast_to_node_instance(RNODE_CLASS(node)->nd_cpath));
-    rb_ivar_set(obj, rb_intern("@super"), ast_to_node_instance(RNODE_CLASS(node)->nd_super));
-    rb_ivar_set(obj, rb_intern("@body"), ast_to_node_instance(RNODE_CLASS(node)->nd_body));
+    rb_ivar_set(obj, rb_intern("@cpath"), ast_to_node_instance(RNODE_MODULE(node)->nd_cpath));
+    rb_ivar_set(obj, rb_intern("@body"), ast_to_node_instance(RNODE_MODULE(node)->nd_body));
 
     return obj;
 }

--- a/ext/kanayago/string_node.c
+++ b/ext/kanayago/string_node.c
@@ -19,12 +19,22 @@ dynamic_string_node_new(const NODE *node)
 {
     VALUE obj = rb_class_new_instance(0, 0, rb_cDynamicStringNode);
     rb_parser_string_t *str = RNODE_DSTR(node)->string;
-    rb_encoding *enc = str->enc;
-    char *ptr = str->ptr;
-    long len = str->len;
+    const NODE *nd_next = (const NODE *)RNODE_DSTR(node)->nd_next;
 
-    rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
-    rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance((const NODE *)RNODE_DSTR(node)->nd_next));
+    if (str) {
+        rb_encoding *enc = str->enc;
+        char *ptr = str->ptr;
+        long len = str->len;
+        rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
+    } else {
+        rb_ivar_set(obj, rb_intern("@string"), rb_str_new("", 0));
+    }
+
+    if (nd_next && nd_next != (NODE *)-1) {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance(nd_next));
+    } else {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), Qnil);
+    }
 
     return obj;
 }
@@ -34,12 +44,22 @@ dynamic_symbol_node_new(const NODE *node)
 {
     VALUE obj = rb_class_new_instance(0, 0, rb_cDynamicSymbolNode);
     rb_parser_string_t *str = RNODE_DSYM(node)->string;
-    rb_encoding *enc = str->enc;
-    char *ptr = str->ptr;
-    long len = str->len;
+    const NODE *nd_next = (const NODE *)RNODE_DSYM(node)->nd_next;
 
-    rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
-    rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance((const NODE *)RNODE_DSYM(node)->nd_next));
+    if (str) {
+        rb_encoding *enc = str->enc;
+        char *ptr = str->ptr;
+        long len = str->len;
+        rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
+    } else {
+        rb_ivar_set(obj, rb_intern("@string"), rb_str_new("", 0));
+    }
+
+    if (nd_next && nd_next != (NODE *)-1) {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance(nd_next));
+    } else {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), Qnil);
+    }
 
     return obj;
 }
@@ -77,12 +97,22 @@ dynamic_execute_string_node_new(const NODE *node)
 {
     VALUE obj = rb_class_new_instance(0, 0, rb_cDynamicExecuteStringNode);
     rb_parser_string_t *str = RNODE_DXSTR(node)->string;
-    rb_encoding *enc = str->enc;
-    char *ptr = str->ptr;
-    long len = str->len;
+    const NODE *nd_next = (const NODE *)RNODE_DXSTR(node)->nd_next;
 
-    rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
-    rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance((const NODE *)RNODE_DXSTR(node)->nd_next));
+    if (str) {
+        rb_encoding *enc = str->enc;
+        char *ptr = str->ptr;
+        long len = str->len;
+        rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
+    } else {
+        rb_ivar_set(obj, rb_intern("@string"), rb_str_new("", 0));
+    }
+
+    if (nd_next && nd_next != (NODE *)-1) {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance(nd_next));
+    } else {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), Qnil);
+    }
 
     return obj;
 }
@@ -112,13 +142,24 @@ dynamic_regexp_node_new(const NODE *node)
 {
     VALUE obj = rb_class_new_instance(0, 0, rb_cDynamicRegexpNode);
     rb_parser_string_t *str = RNODE_DREGX(node)->string;
-    rb_encoding *enc = str->enc;
-    char *ptr = str->ptr;
-    long len = str->len;
     long options = RNODE_DREGX(node)->as.nd_cflag;
+    const NODE *nd_next = (const NODE *)RNODE_DREGX(node)->nd_next;
 
-    rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
-    rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance((const NODE *)RNODE_DREGX(node)->nd_next));
+    if (str) {
+        rb_encoding *enc = str->enc;
+        char *ptr = str->ptr;
+        long len = str->len;
+        rb_ivar_set(obj, rb_intern("@string"), rb_enc_str_new(ptr, len, enc));
+    } else {
+        rb_ivar_set(obj, rb_intern("@string"), rb_str_new("", 0));
+    }
+
+    if (nd_next && nd_next != (NODE *)-1) {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), ast_to_node_instance(nd_next));
+    } else {
+        rb_ivar_set(obj, rb_intern("@next_nodes"), Qnil);
+    }
+
     rb_ivar_set(obj, rb_intern("@options"), LONG2FIX(options));
 
     return obj;

--- a/lib/kanayago/statement_node.rb
+++ b/lib/kanayago/statement_node.rb
@@ -74,7 +74,7 @@ module Kanayago
   end
 
   class ModuleNode
-    attr_reader :cpath, :super, :body
+    attr_reader :cpath, :body
   end
 
   class SingletonClassNode

--- a/test/kanayago/parse_dynamic_symbol_node_test.rb
+++ b/test/kanayago/parse_dynamic_symbol_node_test.rb
@@ -54,4 +54,38 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
     # Static symbols should remain SymbolNode, not DynamicSymbolNode
     assert_instance_of(Kanayago::SymbolNode, body)
   end
+
+  def test_dynamic_symbol_in_hash_with_to_h_block
+    code = <<~'RUBY'
+      SIZES = [16, 32, 48]
+      STYLES = SIZES.to_h do |size|
+        [:"#{size}", { format: 'png', geometry: "#{size}x#{size}#" }]
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ScopeNode, result)
+    refute_nil(result.body)
+  end
+
+  def test_complex_nested_hash_with_dynamic_symbols
+    code = <<~'RUBY'
+      SIZES = [57, 60, 72]
+      CONFIG = {
+        icons: SIZES.to_h do |size|
+          [:"#{size}", {
+            format: 'png',
+            geometry: "#{size}x#{size}#",
+            options: { quality: 90 }
+          }]
+        end.freeze
+      }
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ScopeNode, result)
+    refute_nil(result.body)
+  end
 end

--- a/test/kanayago/parse_module_node_test.rb
+++ b/test/kanayago/parse_module_node_test.rb
@@ -15,4 +15,26 @@ class ParseModuleNodeTest < Minitest::Test
     assert_instance_of(Kanayago::Colon2Node, body.cpath)
     assert_instance_of(Kanayago::ScopeNode, body.body)
   end
+
+  def test_nested_module_with_outer_constant_reference
+    code = <<~RUBY
+      class UserRole
+        FLAGS = {
+          admin: (1 << 0),
+          user: (1 << 1),
+          guest: (1 << 2)
+        }
+
+        module Flags
+          ALL = FLAGS.values.reduce(&:|)
+          DEFAULT = FLAGS[:user]
+        end
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ScopeNode, result)
+    refute_nil(result.body)
+  end
 end


### PR DESCRIPTION
# Fixed
- Fix segmentation fault when parsing dynamic symbols in complex hash structures
- Fix segmentation fault when parsing nested modules with outer constant references
- Fix `module_node_new` to use `RNODE_MODULE` instead of incorrect `RNODE_CLASS` macro
- Add NULL pointer checks in `dynamic_string_node_new`, `dynamic_symbol_node_new`, `dynamic_execute_string_node_new`, and `dynamic_regexp_node_new`

# Changed
- Remove incorrect `@super` field access from `ModuleNode` (modules do not have superclasses)
