### PR TITLE
Fix Ruby head build

### DIFF
--- a/patch/head/copy_target.rb
+++ b/patch/head/copy_target.rb
@@ -13,6 +13,7 @@ RUBY_PARSER_COPY_TARGETS = %w[
   internal/basic_operators.h
   internal/bignum.h
   internal/bits.h
+  internal/box.h
   internal/compile.h
   internal/compilers.h
   internal/complex.h


### PR DESCRIPTION
Kanayago and Ruby head need 'internal/box.h' for 'vm_core.h'.
Added `internal/box.h` in `patch/head/copy_target.rb`
