### PR TITLE
Update bundler to v2.7.2 to suppress warnings on Ruby head

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ DEPENDENCIES
   typeprof
 
 BUNDLED WITH
-   2.6.7
+   2.7.2


### PR DESCRIPTION
Using old bundler with Ruby head causes duplicated constant warnings.
Updated to bundler v2.7.2 to suppress these warnings.
