### PR TITLE
Implement error-tolerant parser with ParseResult wrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `ParseResult` class to wrap AST and error information
+  - `ParseResult#ast` - Returns the parsed AST (ScopeNode)
+  - `ParseResult#error` - Returns SyntaxError object if syntax error occurred, false otherwise
+  - `ParseResult#valid?` - Returns true if no syntax error occurred
+  - `ParseResult#invalid?` - Returns true if syntax error occurred
+  - `Kanayago.parse` now returns `ParseResult` instead of raw AST
+
 ### Fixed
 - Fix parser crash on syntax errors by implementing `rb_syntax_error_append`
   - Previously, `rb_syntax_error_append` was not available in UniversalParser, causing forced termination when syntax errors occurred during parsing
@@ -14,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added proper copyright notice (Copyright (C) 1993-2007 Yukihiro Matsumoto) as the code is ported from Ruby's error.c
   - Updated patch files for both Ruby 3.4 and head versions
   - Syntax errors now display properly instead of crashing the parser
+- Implement error_tolerant mode to continue parsing despite syntax errors
+  - Enable `rb_ruby_parser_error_tolerant` flag for all parsing operations
+  - Parser now accumulates syntax errors in `error_buffer` instead of terminating
+  - Fixed Qfalse handling in `rb_syntax_error_append` (Qfalse is defined as 0, causing `!exc` to evaluate to true)
+  - Added OBJ_FROZEN checks to handle frozen default "compile error" messages in SyntaxError objects
+  - Both AST and error information are now available even when syntax errors occur
+
+### Changed
+- Migrate error_buffer accessor implementation from script to patch files
+  - Moved `rb_ruby_parser_error_buffer_get` accessor function from `script/setup_parser.rb` to patch files
+  - Added parse.c modifications to both `patch/3.4/kanayago.patch` and `patch/head/kanayago.patch`
+  - Improved maintainability and version compatibility by using patch-based approach instead of runtime script modifications
+  - Removed `add_error_buffer_accessor` function from `script/setup_parser.rb`
+- Update all test files to access AST through `ParseResult#ast`
+  - All 93 test files now use `result.ast` instead of direct result access
+  - Tests validate both successful parsing and error handling scenarios
 
 ## [0.4.1]
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,25 @@ gem install pkg/kanayago-0.4.1.gem
 require 'kanayago/kanayago'
 
 result = Kanayago.parse('117 + 117')
+# => #<Kanayago::ParseResult:0x00007f522199c5a8>
+
+p result.ast
 # => #<Kanayago::ScopeNode:0x00007f522199c5a8>
 
-p result.body
+p result.ast.body
 # => #<Kanayago::OperatorCallNode:0x00007f5221b06358>
 
-p result.body.recv
-p result.body.recv.val
+p result.ast.body.recv
+p result.ast.body.recv.val
 # => #<Kanayago::IntegerNode:0x00007f5221b06330>
 # => 117
+
+# Check for syntax errors
+result = Kanayago.parse('def foo')
+p result.valid?
+# => false
+p result.error
+# => #<SyntaxError: syntax error, unexpected end-of-input>
 ```
 
 ## Development

--- a/ext/kanayago/kanayago.c
+++ b/ext/kanayago/kanayago.c
@@ -517,12 +517,22 @@ kanayago_parse(VALUE self, VALUE source)
                                          &ruby_parser_data_type, parser);
     parser->parser_params = parser_params;
 
+    // Enable error tolerant parser
+    rb_ruby_parser_error_tolerant(parser_params);
 
     VALUE vast = rb_parser_compile_string(vparser, "main", source, 0);
 
     rb_ast_t *ast = rb_ruby_ast_data_get(vast);
+    VALUE ast_node = ast_to_node_instance(ast->body.root);
 
-    return ast_to_node_instance(ast->body.root);
+    // Get error_buffer from parser_params using accessor function
+    VALUE error_buffer = rb_ruby_parser_error_buffer_get(parser_params);
+
+    VALUE result = rb_hash_new();
+    rb_hash_aset(result, ID2SYM(rb_intern("ast")), ast_node);
+    rb_hash_aset(result, ID2SYM(rb_intern("error")), error_buffer);
+
+    return result;
 }
 
 RUBY_FUNC_EXPORTED void

--- a/ext/kanayago/kanayago.h
+++ b/ext/kanayago/kanayago.h
@@ -12,6 +12,7 @@ VALUE rb_node_rational_literal_val(const NODE *);
 VALUE rb_node_imaginary_literal_val(const NODE *);
 VALUE rb_node_str_string_val(const NODE *);
 VALUE rb_node_sym_string_val(const NODE *);
+VALUE rb_ruby_parser_error_buffer_get(rb_parser_t *);
 
 // Add extern for Kanayago
 extern const rb_data_type_t ruby_parser_data_type;

--- a/lib/kanayago.rb
+++ b/lib/kanayago.rb
@@ -14,7 +14,26 @@ require_relative 'kanayago/constant_node'
 
 # Parse Ruby code with Ruby's Parser(Universal Parser)
 module Kanayago
+  class ParseResult
+    attr_reader :ast, :error
+
+    def initialize(ast, error)
+      @ast = ast
+      @error = error
+    end
+
+    def invalid?
+      @error.is_a?(SyntaxError)
+    end
+
+    def valid?
+      !invalid?
+    end
+  end
+
   def self.parse(source)
-    kanayago_parse(source)
+    kanayago_parse(source) in { ast:, error: }
+
+    ParseResult.new(ast, error)
   end
 end

--- a/patch/3.4/kanayago.patch
+++ b/patch/3.4/kanayago.patch
@@ -36,7 +36,7 @@ diff --git a/ext/kanayago/ruby_parser.c b/ext/kanayago/ruby_parser.c
 index 267f619..841db65 100644
 --- a/ext/kanayago/ruby_parser.c
 +++ b/ext/kanayago/ruby_parser.c
-@@ -34,6 +34,89 @@
+@@ -34,6 +34,100 @@
 
  #define parser_encoding const void
 
@@ -91,11 +91,13 @@ index 267f619..841db65 100644
 +static VALUE
 +syntax_error_with_path(VALUE exc, VALUE file, VALUE *mesg, rb_encoding *enc)
 +{
-+    if (NIL_P(exc)) {
++    // Create new SyntaxError if exc is nil or Qfalse (for error_tolerant mode)
++    if (NIL_P(exc) || exc == Qfalse) {
 +        exc = rb_class_new_instance(0, 0, rb_eSyntaxError);
 +    }
 +    *mesg = rb_attr_get(exc, rb_intern("mesg"));
-+    if (NIL_P(*mesg)) {
++    // Check if mesg is nil or frozen (default "compile error" may be frozen)
++    if (NIL_P(*mesg) || OBJ_FROZEN(*mesg)) {
 +        *mesg = rb_enc_str_new(0, 0, enc);
 +        rb_ivar_set(exc, rb_intern("mesg"), *mesg);
 +    }
@@ -109,10 +111,19 @@ index 267f619..841db65 100644
 +{
 +    const char *fn = NIL_P(file) ? NULL : RSTRING_PTR(file);
 +    if (!exc) {
-+        VALUE mesg = rb_enc_str_new(0, 0, enc);
++        // For error_tolerant mode, create SyntaxError even when writing to stderr
++        exc = rb_class_new_instance(0, 0, rb_eSyntaxError);
++        VALUE mesg = rb_attr_get(exc, rb_intern("mesg"));
++        // Check if mesg is nil or frozen (default "compile error" may be frozen)
++        if (NIL_P(mesg) || OBJ_FROZEN(mesg)) {
++            mesg = rb_enc_str_new(0, 0, enc);
++            rb_ivar_set(exc, rb_intern("mesg"), mesg);
++        }
 +        err_vcatf(mesg, NULL, fn, line, fmt, args);
-+        rb_str_cat_cstr(mesg, "\n");
-+        rb_write_error_str(mesg);
++        // Still write to stderr for compatibility
++        VALUE err_mesg = rb_str_dup(mesg);
++        rb_str_cat_cstr(err_mesg, "\n");
++        rb_write_error_str(err_mesg);
 +    }
 +    else {
 +        VALUE mesg;
@@ -126,7 +137,7 @@ index 267f619..841db65 100644
  RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 6, 0)
  static VALUE
  syntax_error_append(VALUE exc, VALUE file, int line, int column,
-@@ -314,6 +397,44 @@ enc_mbc_to_codepoint(const char *p, const char *e, parser_encoding *enc)
+@@ -314,6 +408,44 @@ enc_mbc_to_codepoint(const char *p, const char *e, parser_encoding *enc)
 
  extern VALUE rb_eArgError;
 
@@ -171,7 +182,7 @@ index 267f619..841db65 100644
  static const rb_parser_config_t rb_global_parser_config = {
      .malloc = ruby_xmalloc,
      .calloc = ruby_xcalloc,
-@@ -325,9 +446,9 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -325,9 +457,9 @@ static const rb_parser_config_t rb_global_parser_config = {
      .zalloc = zalloc,
      .rb_memmove = memmove2,
      .nonempty_memcpy = nonempty_memcpy,
@@ -183,7 +194,7 @@ index 267f619..841db65 100644
      .reg_named_capture_assign = reg_named_capture_assign,
 
      .attr_get = rb_attr_get,
-@@ -335,7 +456,7 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -335,7 +467,7 @@ static const rb_parser_config_t rb_global_parser_config = {
      .ary_new_from_args = rb_ary_new_from_args,
      .ary_unshift = rb_ary_unshift,
 
@@ -192,7 +203,7 @@ index 267f619..841db65 100644
      .is_local_id = is_local_id2,
      .is_attrset_id = is_attrset_id2,
      .is_global_name_punct = is_global_name_punct,
-@@ -365,7 +486,7 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -365,7 +497,7 @@ static const rb_parser_config_t rb_global_parser_config = {
 
      .int2num = rb_int2num_inline,
 
@@ -201,7 +212,7 @@ index 267f619..841db65 100644
      .write_error_str = rb_write_error_str,
      .io_write = rb_io_write,
      .io_flush = rb_io_flush,
-@@ -412,8 +533,8 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -412,8 +544,8 @@ static const rb_parser_config_t rb_global_parser_config = {
      .gc_guard = gc_guard,
      .gc_mark = rb_gc_mark,
 
@@ -212,7 +223,7 @@ index 267f619..841db65 100644
      .memcicmp = rb_memcicmp,
 
      .compile_warn = rb_compile_warn,
-@@ -443,27 +564,6 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -443,27 +575,6 @@ static const rb_parser_config_t rb_global_parser_config = {
  };
  #endif
 
@@ -240,7 +251,7 @@ index 267f619..841db65 100644
  static void
  parser_mark(void *ptr)
  {
-@@ -501,7 +601,8 @@ parser_memsize(const void *ptr)
+@@ -501,7 +612,8 @@ parser_memsize(const void *ptr)
      return rb_ruby_parser_memsize(parser->parser_params);
  }
 
@@ -250,3 +261,22 @@ index 267f619..841db65 100644
      "parser",
      {
          parser_mark,
+diff --git a/ext/kanayago/parse.c b/ext/kanayago/parse.c
+--- a/ext/kanayago/parse.c
++++ b/ext/kanayago/parse.c
+@@ -26941,6 +26941,15 @@ ripper_value(struct parser_params *p)
+     return p->value;
+ }
+
++#else /* !RIPPER */
++
++// Accessor function for error_buffer (for Kanayago)
++VALUE
++rb_ruby_parser_error_buffer_get(rb_parser_t *p)
++{
++    return p->error_buffer;
++}
++
+ #endif /* RIPPER */
+ /*
+  * Local variables:

--- a/patch/head/kanayago.patch
+++ b/patch/head/kanayago.patch
@@ -36,7 +36,7 @@ diff --git a/ext/kanayago/ruby_parser.c b/ext/kanayago/ruby_parser.c
 index 267f619..841db65 100644
 --- a/ext/kanayago/ruby_parser.c
 +++ b/ext/kanayago/ruby_parser.c
-@@ -34,6 +34,89 @@
+@@ -34,6 +34,100 @@
 
  #define parser_encoding const void
 
@@ -91,11 +91,13 @@ index 267f619..841db65 100644
 +static VALUE
 +syntax_error_with_path(VALUE exc, VALUE file, VALUE *mesg, rb_encoding *enc)
 +{
-+    if (NIL_P(exc)) {
++    // Create new SyntaxError if exc is nil or Qfalse (for error_tolerant mode)
++    if (NIL_P(exc) || exc == Qfalse) {
 +        exc = rb_class_new_instance(0, 0, rb_eSyntaxError);
 +    }
 +    *mesg = rb_attr_get(exc, rb_intern("mesg"));
-+    if (NIL_P(*mesg)) {
++    // Check if mesg is nil or frozen (default "compile error" may be frozen)
++    if (NIL_P(*mesg) || OBJ_FROZEN(*mesg)) {
 +        *mesg = rb_enc_str_new(0, 0, enc);
 +        rb_ivar_set(exc, rb_intern("mesg"), *mesg);
 +    }
@@ -109,10 +111,19 @@ index 267f619..841db65 100644
 +{
 +    const char *fn = NIL_P(file) ? NULL : RSTRING_PTR(file);
 +    if (!exc) {
-+        VALUE mesg = rb_enc_str_new(0, 0, enc);
++        // For error_tolerant mode, create SyntaxError even when writing to stderr
++        exc = rb_class_new_instance(0, 0, rb_eSyntaxError);
++        VALUE mesg = rb_attr_get(exc, rb_intern("mesg"));
++        // Check if mesg is nil or frozen (default "compile error" may be frozen)
++        if (NIL_P(mesg) || OBJ_FROZEN(mesg)) {
++            mesg = rb_enc_str_new(0, 0, enc);
++            rb_ivar_set(exc, rb_intern("mesg"), mesg);
++        }
 +        err_vcatf(mesg, NULL, fn, line, fmt, args);
-+        rb_str_cat_cstr(mesg, "\n");
-+        rb_write_error_str(mesg);
++        // Still write to stderr for compatibility
++        VALUE err_mesg = rb_str_dup(mesg);
++        rb_str_cat_cstr(err_mesg, "\n");
++        rb_write_error_str(err_mesg);
 +    }
 +    else {
 +        VALUE mesg;
@@ -126,7 +137,7 @@ index 267f619..841db65 100644
  RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 6, 0)
  static VALUE
  syntax_error_append(VALUE exc, VALUE file, int line, int column,
-@@ -314,6 +397,44 @@ enc_mbc_to_codepoint(const char *p, const char *e, parser_encoding *enc)
+@@ -314,6 +408,44 @@ enc_mbc_to_codepoint(const char *p, const char *e, parser_encoding *enc)
 
  extern VALUE rb_eArgError;
 
@@ -171,7 +182,7 @@ index 267f619..841db65 100644
  static const rb_parser_config_t rb_global_parser_config = {
      .malloc = ruby_xmalloc,
      .calloc = ruby_xcalloc,
-@@ -325,9 +446,9 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -325,9 +457,9 @@ static const rb_parser_config_t rb_global_parser_config = {
      .zalloc = zalloc,
      .rb_memmove = memmove2,
      .nonempty_memcpy = nonempty_memcpy,
@@ -183,7 +194,7 @@ index 267f619..841db65 100644
      .reg_named_capture_assign = reg_named_capture_assign,
 
      .attr_get = rb_attr_get,
-@@ -335,7 +456,7 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -335,7 +467,7 @@ static const rb_parser_config_t rb_global_parser_config = {
      .ary_new_from_args = rb_ary_new_from_args,
      .ary_unshift = rb_ary_unshift,
 
@@ -192,7 +203,7 @@ index 267f619..841db65 100644
      .is_local_id = is_local_id2,
      .is_attrset_id = is_attrset_id2,
      .is_global_name_punct = is_global_name_punct,
-@@ -365,7 +486,7 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -365,7 +497,7 @@ static const rb_parser_config_t rb_global_parser_config = {
 
      .int2num = rb_int2num_inline,
 
@@ -201,7 +212,7 @@ index 267f619..841db65 100644
      .write_error_str = rb_write_error_str,
      .io_write = rb_io_write,
      .io_flush = rb_io_flush,
-@@ -412,8 +533,8 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -412,8 +544,8 @@ static const rb_parser_config_t rb_global_parser_config = {
      .gc_guard = gc_guard,
      .gc_mark = rb_gc_mark,
 
@@ -212,7 +223,7 @@ index 267f619..841db65 100644
      .memcicmp = rb_memcicmp,
 
      .compile_warn = rb_compile_warn,
-@@ -443,27 +564,6 @@ static const rb_parser_config_t rb_global_parser_config = {
+@@ -443,27 +575,6 @@ static const rb_parser_config_t rb_global_parser_config = {
  };
  #endif
 
@@ -240,7 +251,7 @@ index 267f619..841db65 100644
  static void
  parser_mark(void *ptr)
  {
-@@ -501,7 +601,8 @@ parser_memsize(const void *ptr)
+@@ -501,7 +612,8 @@ parser_memsize(const void *ptr)
      return rb_ruby_parser_memsize(parser->parser_params);
  }
 
@@ -250,3 +261,22 @@ index 267f619..841db65 100644
      "parser",
      {
          parser_mark,
+diff --git a/ext/kanayago/parse.c b/ext/kanayago/parse.c
+--- a/ext/kanayago/parse.c
++++ b/ext/kanayago/parse.c
+@@ -27391,6 +27391,15 @@ ripper_value(struct parser_params *p)
+     return p->value;
+ }
+
++#else /* !RIPPER */
++
++// Accessor function for error_buffer (for Kanayago)
++VALUE
++rb_ruby_parser_error_buffer_get(rb_parser_t *p)
++{
++    return p->error_buffer;
++}
++
+ #endif /* RIPPER */
+ /*
+  * Local variables:

--- a/test/kanayago/global_assignment_node_test.rb
+++ b/test/kanayago/global_assignment_node_test.rb
@@ -6,7 +6,7 @@ class ParseGlobalAssignmentNodeTest < Minitest::Test
   def test_parse_global_assignment_node
     result = Kanayago.parse('$var = 117')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::GlobalAssignmentNode, body)
     assert_equal(:$var, body.id)

--- a/test/kanayago/parse_alias_node_test.rb
+++ b/test/kanayago/parse_alias_node_test.rb
@@ -6,7 +6,7 @@ class ParseAliasNodeTest < Minitest::Test
   def test_parse_alias_node
     result = Kanayago.parse('alias v g')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::AliasNode, body)
     assert_instance_of(Kanayago::SymbolNode, body.first)

--- a/test/kanayago/parse_and_node_test.rb
+++ b/test/kanayago/parse_and_node_test.rb
@@ -6,7 +6,7 @@ class ParseAndNodeTest < Minitest::Test
   def test_parse_and_node
     result = Kanayago.parse('1 && 2')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::AndNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.first)

--- a/test/kanayago/parse_args_aux_test.rb
+++ b/test/kanayago/parse_args_aux_test.rb
@@ -6,8 +6,8 @@ class ParseArgsAuxTest < Minitest::Test
   def test_parse_method_with_optional_args
     result = Kanayago.parse('def foo(a, b = 1); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)
@@ -16,8 +16,8 @@ class ParseArgsAuxTest < Minitest::Test
   def test_parse_method_with_multiple_args
     result = Kanayago.parse('def bar(x, y, z = 2); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)

--- a/test/kanayago/parse_args_cat_test.rb
+++ b/test/kanayago/parse_args_cat_test.rb
@@ -6,8 +6,8 @@ class ParseArgsCatTest < Minitest::Test
   def test_parse_args_concatenation
     result = Kanayago.parse('foo(a, *b)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     refute_nil(call_node.args)
@@ -16,8 +16,8 @@ class ParseArgsCatTest < Minitest::Test
   def test_parse_args_concatenation_with_multiple_args
     result = Kanayago.parse('bar(x, y, *z)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     refute_nil(call_node.args)

--- a/test/kanayago/parse_args_push_test.rb
+++ b/test/kanayago/parse_args_push_test.rb
@@ -6,8 +6,8 @@ class ParseArgsPushTest < Minitest::Test
   def test_parse_args_push
     result = Kanayago.parse('foo(*a, b)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     refute_nil(call_node.args)
@@ -16,8 +16,8 @@ class ParseArgsPushTest < Minitest::Test
   def test_parse_args_push_with_multiple_trailing
     result = Kanayago.parse('bar(*x, y, z)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     refute_nil(call_node.args)

--- a/test/kanayago/parse_arguments_node_test.rb
+++ b/test/kanayago/parse_arguments_node_test.rb
@@ -10,7 +10,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -34,7 +34,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -53,7 +53,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -70,7 +70,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -88,7 +88,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -105,7 +105,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -122,7 +122,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -139,7 +139,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 
@@ -160,7 +160,7 @@ class ParseArgumentsNodeTest < Minitest::Test
       end
     CODE
 
-    args = result.body.defn.args
+    args = result.ast.body.defn.args
 
     assert_instance_of(Kanayago::ArgumentsNode, args)
 

--- a/test/kanayago/parse_array_pattern_node_test.rb
+++ b/test/kanayago/parse_array_pattern_node_test.rb
@@ -6,7 +6,7 @@ class ParseArrayPatternNodeTest < Minitest::Test
   def test_parse_simple_array_pattern
     result = Kanayago.parse('case [1, 2]; in [a, b]; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
     array_pattern = in_node.head
@@ -21,7 +21,7 @@ class ParseArrayPatternNodeTest < Minitest::Test
   def test_parse_array_pattern_with_rest
     result = Kanayago.parse('case [1, 2, 3]; in [*, a, b]; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
     array_pattern = in_node.head
@@ -36,7 +36,7 @@ class ParseArrayPatternNodeTest < Minitest::Test
   def test_parse_array_pattern_with_pre_and_post
     result = Kanayago.parse('case [1, 2, 3, 4]; in [a, *, b]; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
     array_pattern = in_node.head

--- a/test/kanayago/parse_attrasgn_test.rb
+++ b/test/kanayago/parse_attrasgn_test.rb
@@ -8,8 +8,8 @@ class ParseAttrasgnTest < Minitest::Test
       obj.attr = 117
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::AttributeAssignmentNode, body)
     assert_equal(:attr=, body.mid)
@@ -22,8 +22,8 @@ class ParseAttrasgnTest < Minitest::Test
       obj[key] = value
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::AttributeAssignmentNode, body)
     assert_equal(:[]=, body.mid)

--- a/test/kanayago/parse_back_ref_test.rb
+++ b/test/kanayago/parse_back_ref_test.rb
@@ -9,8 +9,8 @@ class ParseBackRefTest < Minitest::Test
       p $&
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     assert_equal(2, body.size)
@@ -32,7 +32,7 @@ class ParseBackRefTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IfStatementNode, body)
 
@@ -47,7 +47,7 @@ class ParseBackRefTest < Minitest::Test
       puts "matched: \#{$&}"
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_equal(2, body.size)
 

--- a/test/kanayago/parse_block_pass_test.rb
+++ b/test/kanayago/parse_block_pass_test.rb
@@ -6,8 +6,8 @@ class ParseBlockPassTest < Minitest::Test
   def test_parse_block_pass_symbol_to_proc
     result = Kanayago.parse('[1, 2].map(&:to_s)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, call_node)
     assert_equal(:map, call_node.mid)
@@ -22,8 +22,8 @@ class ParseBlockPassTest < Minitest::Test
   def test_parse_block_pass_variable
     result = Kanayago.parse('foo(&block)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     assert_equal(:foo, call_node.mid)
@@ -38,8 +38,8 @@ class ParseBlockPassTest < Minitest::Test
   def test_parse_block_pass_in_method_definition
     result = Kanayago.parse('def bar(&blk); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     assert_equal(:bar, defn.mid)

--- a/test/kanayago/parse_break_test.rb
+++ b/test/kanayago/parse_break_test.rb
@@ -6,7 +6,7 @@ class ParseBreakTest < Minitest::Test
   def test_parse_break_basic
     result = Kanayago.parse('loop { break }')
 
-    scope = result
+    scope = result.ast
 
     assert_instance_of(Kanayago::ScopeNode, scope)
 
@@ -27,7 +27,7 @@ class ParseBreakTest < Minitest::Test
   def test_parse_break_with_value
     result = Kanayago.parse('loop { break 117 }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
     iter_body = iter.body
     break_node = iter_body.body
@@ -39,7 +39,7 @@ class ParseBreakTest < Minitest::Test
   def test_parse_break_with_multiple_values
     result = Kanayago.parse('loop { break 1, 2 }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
     iter_body = iter.body
     break_node = iter_body.body
@@ -52,7 +52,7 @@ class ParseBreakTest < Minitest::Test
   def test_parse_break_conditional
     result = Kanayago.parse('loop { break if true }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
     iter_body = iter.body
     if_node = iter_body.body
@@ -68,7 +68,7 @@ class ParseBreakTest < Minitest::Test
   def test_parse_break_in_iterator
     result = Kanayago.parse('[1, 2, 3].each { |i| break }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
 
     assert_instance_of(Kanayago::IterNode, iter)

--- a/test/kanayago/parse_case2_test.rb
+++ b/test/kanayago/parse_case2_test.rb
@@ -13,8 +13,8 @@ class ParseCase2Test < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::Case2Node, body)
 
@@ -29,8 +29,8 @@ class ParseCase2Test < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::Case2Node, body)
 

--- a/test/kanayago/parse_case_test.rb
+++ b/test/kanayago/parse_case_test.rb
@@ -15,8 +15,8 @@ class ParseCaseTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CaseNode, body)
 
@@ -33,8 +33,8 @@ class ParseCaseTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CaseNode, body)
 

--- a/test/kanayago/parse_class_test.rb
+++ b/test/kanayago/parse_class_test.rb
@@ -9,10 +9,10 @@ class ParseClassTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ClassNode, body)
     assert_nil(body.super)

--- a/test/kanayago/parse_class_variable_assignment_node_test.rb
+++ b/test/kanayago/parse_class_variable_assignment_node_test.rb
@@ -6,7 +6,7 @@ class ParseClassVariableAssignmentNodeTest < Minitest::Test
   def test_parse_class_variable_assignment_node
     result = Kanayago.parse('@@var = 117')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ClassVariableAssignmentNode, body)
     assert_equal(:@@var, body.id)

--- a/test/kanayago/parse_class_variable_node_test.rb
+++ b/test/kanayago/parse_class_variable_node_test.rb
@@ -6,7 +6,7 @@ class ParseClassVariableNodeTest < Minitest::Test
   def test_parser_class_variable_node
     result = Kanayago.parse('@@var')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ClassVariableNode, body)
     assert_equal(:@@var, body.vid)

--- a/test/kanayago/parse_colon3_test.rb
+++ b/test/kanayago/parse_colon3_test.rb
@@ -6,7 +6,7 @@ class ParseColon3Test < Minitest::Test
   def test_parse_colon3_node
     result = Kanayago.parse('::String')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::Colon3Node, body)
     assert_equal(:String, body.mid)

--- a/test/kanayago/parse_const_decl_test.rb
+++ b/test/kanayago/parse_const_decl_test.rb
@@ -6,10 +6,10 @@ class ParseConstDeclTest < Minitest::Test
   def test_parse_const_decl
     result = Kanayago.parse('S = 117')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ConstantDeclarationNode, body)
     assert_equal(:S, body.vid)

--- a/test/kanayago/parse_const_test.rb
+++ b/test/kanayago/parse_const_test.rb
@@ -6,10 +6,10 @@ class ParseConstTest < Minitest::Test
   def test_parse_const
     result = Kanayago.parse('Class')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ConstantNode, body)
     assert_equal(:Class, body.vid)
@@ -21,10 +21,10 @@ class ParseConstTest < Minitest::Test
       p S
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     assert_equal(2, body.size)

--- a/test/kanayago/parse_dasgn_test.rb
+++ b/test/kanayago/parse_dasgn_test.rb
@@ -6,8 +6,8 @@ class ParseDasgnTest < Minitest::Test
   def test_parse_dynamic_assignment_in_block
     result = Kanayago.parse('1.times { a = 1 }')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    iter_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    iter_node = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, iter_node)
     refute_nil(iter_node.iter)

--- a/test/kanayago/parse_defined_test.rb
+++ b/test/kanayago/parse_defined_test.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 class ParseDefinedTest < Minitest::Test
   def test_parse_defined_basic_variable
     result = Kanayago.parse('defined? x')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::VariableCallNode, body.head)
@@ -13,7 +13,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_instance_variable
     result = Kanayago.parse('defined? @ivar')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::InstanceVariableNode, body.head)
@@ -21,7 +21,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_class_variable
     result = Kanayago.parse('defined? @@cvar')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::ClassVariableNode, body.head)
@@ -29,7 +29,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_global_variable
     result = Kanayago.parse('defined? $gvar')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::GlobalVariableNode, body.head)
@@ -37,7 +37,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_constant
     result = Kanayago.parse('defined? CONST')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::ConstantNode, body.head)
@@ -45,7 +45,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_nested_constant
     result = Kanayago.parse('defined? Foo::Bar')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::Colon2Node, body.head)
@@ -53,7 +53,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_method_call
     result = Kanayago.parse('defined? method_name')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::VariableCallNode, body.head)
@@ -61,7 +61,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_in_condition
     result = Kanayago.parse('if defined?(x); puts "defined"; end')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IfStatementNode, body)
     assert_instance_of(Kanayago::DefinedNode, body.cond)
@@ -69,7 +69,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_in_assignment
     result = Kanayago.parse('result = defined?(x)')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::LocalAssignmentNode, body)
     assert_instance_of(Kanayago::DefinedNode, body.value)
@@ -77,7 +77,7 @@ class ParseDefinedTest < Minitest::Test
 
   def test_parse_defined_nested
     result = Kanayago.parse('defined?(defined?(x))')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinedNode, body)
     assert_instance_of(Kanayago::DefinedNode, body.head)

--- a/test/kanayago/parse_defn_test.rb
+++ b/test/kanayago/parse_defn_test.rb
@@ -10,10 +10,10 @@ class ParseDefnTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, body)
     assert_equal(:kanayago, body.mid)

--- a/test/kanayago/parse_defs_test.rb
+++ b/test/kanayago/parse_defs_test.rb
@@ -10,8 +10,8 @@ class ParseDefsTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::SingletonDefinitionNode, body)
     assert_equal(:kanayago, body.mid)

--- a/test/kanayago/parse_dvar_test.rb
+++ b/test/kanayago/parse_dvar_test.rb
@@ -9,8 +9,8 @@ class ParseDvarTest < Minitest::Test
       lambda { x }
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     assert_equal(2, body.size)
@@ -38,8 +38,8 @@ class ParseDvarTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
 
@@ -63,7 +63,7 @@ class ParseDvarTest < Minitest::Test
       proc { value }
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
 

--- a/test/kanayago/parse_dynamic_execute_string_node_test.rb
+++ b/test/kanayago/parse_dynamic_execute_string_node_test.rb
@@ -8,7 +8,7 @@ class ParseDynamicExecuteStringNodeTest < Minitest::Test
     result = Kanayago.parse('`echo #{name}`')
     # rubocop:enable Lint/InterpolationCheck
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicExecuteStringNode, body)
     assert_equal('echo ', body.string)

--- a/test/kanayago/parse_dynamic_regexp_node_test.rb
+++ b/test/kanayago/parse_dynamic_regexp_node_test.rb
@@ -8,7 +8,7 @@ class ParseDynamicRegexpNodeTest < Minitest::Test
     result = Kanayago.parse('/hello #{name}/')
     # rubocop:enable Lint/InterpolationCheck
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicRegexpNode, body)
     assert_equal('hello ', body.string)
@@ -21,7 +21,7 @@ class ParseDynamicRegexpNodeTest < Minitest::Test
     result = Kanayago.parse('/hello #{name}/im')
     # rubocop:enable Lint/InterpolationCheck
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicRegexpNode, body)
     assert_equal('hello ', body.string)

--- a/test/kanayago/parse_dynamic_string_node_test.rb
+++ b/test/kanayago/parse_dynamic_string_node_test.rb
@@ -6,7 +6,7 @@ class ParseDynamicStringNodeTest < Minitest::Test
   def test_parse_dynamic_string_node
     result = Kanayago.parse('"S#{117}"')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicStringNode, body)
     assert_equal('S', body.string)

--- a/test/kanayago/parse_dynamic_symbol_node_test.rb
+++ b/test/kanayago/parse_dynamic_symbol_node_test.rb
@@ -6,7 +6,7 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
   def test_parse_dynamic_symbol_node
     result = Kanayago.parse(':"S#{117}"')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicSymbolNode, body)
     assert_equal('S', body.string)
@@ -18,7 +18,7 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
   def test_parse_empty_interpolation
     result = Kanayago.parse(':"#{""}"')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicSymbolNode, body)
     assert_equal('', body.string)
@@ -30,7 +30,7 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
   def test_parse_multiple_interpolations
     result = Kanayago.parse(':"#{a}_#{b}"')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::DynamicSymbolNode, body)
     assert_instance_of(Kanayago::ListNode, body.next_nodes)
@@ -49,7 +49,7 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
   def test_backward_compatibility_static_symbol
     result = Kanayago.parse(':static')
 
-    body = result.body
+    body = result.ast.body
 
     # Static symbols should remain SymbolNode, not DynamicSymbolNode
     assert_instance_of(Kanayago::SymbolNode, body)
@@ -65,8 +65,8 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
 
     result = Kanayago.parse(code)
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    refute_nil(result.body)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    refute_nil(result.ast.body)
   end
 
   def test_complex_nested_hash_with_dynamic_symbols
@@ -85,7 +85,7 @@ class ParseDynamicSymbolNodeTest < Minitest::Test
 
     result = Kanayago.parse(code)
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    refute_nil(result.body)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    refute_nil(result.ast.body)
   end
 end

--- a/test/kanayago/parse_embedded_expression_string_node_test.rb
+++ b/test/kanayago/parse_embedded_expression_string_node_test.rb
@@ -6,7 +6,7 @@ class ParseEmbeddedExpressionStringNodeTest < Minitest::Test
   def test_parse_embedded_expression_string_node_test
     result = Kanayago.parse('"S#{117}"')
 
-    next_head_node = result.body.next_nodes.val.first
+    next_head_node = result.ast.body.next_nodes.val.first
 
     assert_instance_of(Kanayago::EmbeddedExpressionStringNode, next_head_node)
     assert_instance_of(Kanayago::IntegerNode, next_head_node.body)

--- a/test/kanayago/parse_encoding_node_test.rb
+++ b/test/kanayago/parse_encoding_node_test.rb
@@ -6,7 +6,7 @@ class ParseEncodingNodeTest < Minitest::Test
   def test_parse_encoding_node
     result = Kanayago.parse('__ENCODING__')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::EncodingNode, body)
     assert_equal(Encoding::UTF_8, body.val)

--- a/test/kanayago/parse_ensure_test.rb
+++ b/test/kanayago/parse_ensure_test.rb
@@ -12,7 +12,7 @@ class ParseEnsureTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::EnsureNode, body)
     assert_instance_of(Kanayago::VariableCallNode, body.head)
@@ -30,7 +30,7 @@ class ParseEnsureTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::EnsureNode, body)
     assert_instance_of(Kanayago::RescueNode, body.head)
@@ -47,7 +47,7 @@ class ParseEnsureTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::EnsureNode, body)
     refute_nil(body.head)

--- a/test/kanayago/parse_execute_string_node_test.rb
+++ b/test/kanayago/parse_execute_string_node_test.rb
@@ -6,7 +6,7 @@ class ParseExecuteStringNodeTest < Minitest::Test
   def test_parse_execute_string_node
     result = Kanayago.parse('`echo hello`')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ExecuteStringNode, body)
     assert_equal('echo hello', body.ptr)

--- a/test/kanayago/parse_false_node_test.rb
+++ b/test/kanayago/parse_false_node_test.rb
@@ -6,7 +6,7 @@ class ParseFalseNodeTest < Minitest::Test
   def test_parse_false_node
     result = Kanayago.parse('false')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::FalseNode, body)
     refute(body.val)

--- a/test/kanayago/parse_fcall_test.rb
+++ b/test/kanayago/parse_fcall_test.rb
@@ -6,10 +6,10 @@ class ParseFcallTest < Minitest::Test
   def test_parse_fcall
     result = Kanayago.parse('p 117')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, body)
     assert_equal(:p, body.mid)

--- a/test/kanayago/parse_file_node_test.rb
+++ b/test/kanayago/parse_file_node_test.rb
@@ -6,7 +6,7 @@ class ParseFileNOdeTest < Minitest::Test
   def test_parse_file_node
     result = Kanayago.parse('__FILE__')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::FileNode, body)
     assert_equal('main', body.ptr)

--- a/test/kanayago/parse_find_pattern_node_test.rb
+++ b/test/kanayago/parse_find_pattern_node_test.rb
@@ -8,7 +8,7 @@ class ParseFindPatternNodeTest < Minitest::Test
     # Note: This might be represented as ARYPTN depending on Ruby version
     result = Kanayago.parse('case [1, 2, 3, 4, 5]; in [*, a, b, *]; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
     pattern = in_node.head

--- a/test/kanayago/parse_flip_flop_test.rb
+++ b/test/kanayago/parse_flip_flop_test.rb
@@ -10,8 +10,8 @@ class ParseFlipFlopTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    if_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    if_node = result.ast.body
 
     assert_instance_of(Kanayago::IfStatementNode, if_node)
 
@@ -29,8 +29,8 @@ class ParseFlipFlopTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    if_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    if_node = result.ast.body
 
     assert_instance_of(Kanayago::IfStatementNode, if_node)
 

--- a/test/kanayago/parse_float_test.rb
+++ b/test/kanayago/parse_float_test.rb
@@ -6,10 +6,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float
     result = Kanayago.parse('1.17')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::FloatNode, body)
     assert_in_delta(1.17, body.val)
@@ -19,10 +19,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_plus_opcall
     result = Kanayago.parse('1.17 + 1.17')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)
@@ -37,10 +37,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_minus_opcall
     result = Kanayago.parse('1.17 - 1.17')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)
@@ -55,10 +55,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_times_opcall
     result = Kanayago.parse('1.17 * 1.17')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)
@@ -73,10 +73,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_div_opcall
     result = Kanayago.parse('1.17 / 1.17')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)
@@ -91,10 +91,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_remainder_opcall
     result = Kanayago.parse('1.17 % 1.17')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)
@@ -109,10 +109,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_call
     result = Kanayago.parse('1.17.to_i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)
@@ -123,10 +123,10 @@ class ParseFloatTest < Minitest::Test
   def test_parse_float_call_with_arg
     result = Kanayago.parse('1.17.to_i(10)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::FloatNode, body.recv)

--- a/test/kanayago/parse_for_masgn_test.rb
+++ b/test/kanayago/parse_for_masgn_test.rb
@@ -6,8 +6,8 @@ class ParseForMasgnTest < Minitest::Test
   def test_parse_for_with_multiple_assignment
     result = Kanayago.parse('for a, b in [[1, 2]]; end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    for_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    for_node = result.ast.body
 
     assert_instance_of(Kanayago::ForNode, for_node)
     refute_nil(for_node.iter)

--- a/test/kanayago/parse_for_node_test.rb
+++ b/test/kanayago/parse_for_node_test.rb
@@ -10,7 +10,7 @@ class ParseForNodeTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ForNode, body)
     assert_instance_of(Kanayago::ListNode, body.iter)

--- a/test/kanayago/parse_global_variable_node_test.rb
+++ b/test/kanayago/parse_global_variable_node_test.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 class ParseIvarTest < Minitest::Test
   def test_parse_ivar
     result = Kanayago.parse('$kanayago')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::GlobalVariableNode, body)
     assert_equal(:$kanayago, body.vid)

--- a/test/kanayago/parse_hash_pattern_node_test.rb
+++ b/test/kanayago/parse_hash_pattern_node_test.rb
@@ -6,7 +6,7 @@ class ParseHashPatternNodeTest < Minitest::Test
   def test_parse_simple_hash_pattern
     result = Kanayago.parse('case {x: 1}; in {x: a}; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
     hash_pattern = in_node.head
@@ -20,7 +20,7 @@ class ParseHashPatternNodeTest < Minitest::Test
   def test_parse_hash_pattern_with_multiple_keys
     result = Kanayago.parse('case {x: 1, y: 2}; in {x: a, y: b}; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
     hash_pattern = in_node.head

--- a/test/kanayago/parse_hash_test.rb
+++ b/test/kanayago/parse_hash_test.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 class ParseHashTest < Minitest::Test
   def test_parse_empty_hash
     result = Kanayago.parse('{}')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::HashNode, body)
     assert(body.brace)
@@ -14,7 +14,7 @@ class ParseHashTest < Minitest::Test
 
   def test_parse_hash_with_symbol_keys
     result = Kanayago.parse('{a: 1, b: 2}')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::HashNode, body)
     assert(body.brace)
@@ -23,7 +23,7 @@ class ParseHashTest < Minitest::Test
 
   def test_parse_hash_with_string_keys
     result = Kanayago.parse('{"key" => "value"}')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::HashNode, body)
     assert(body.brace)
@@ -32,7 +32,7 @@ class ParseHashTest < Minitest::Test
 
   def test_parse_nested_hash
     result = Kanayago.parse('{a: {b: 1}}')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::HashNode, body)
     assert(body.brace)

--- a/test/kanayago/parse_if_test.rb
+++ b/test/kanayago/parse_if_test.rb
@@ -11,10 +11,10 @@ class ParseIfTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     assert_equal(2, body.size)

--- a/test/kanayago/parse_imaginary_test.rb
+++ b/test/kanayago/parse_imaginary_test.rb
@@ -6,10 +6,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary
     result = Kanayago.parse('117i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ImaginaryNode, body)
     assert_equal((0 + 117i), body.val)
@@ -22,10 +22,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary_plus_opcall
     result = Kanayago.parse('117i + 117i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::ImaginaryNode, body.recv)
@@ -40,10 +40,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary_minus_opcall
     result = Kanayago.parse('117i - 117i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::ImaginaryNode, body.recv)
@@ -58,10 +58,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary_times_opcall
     result = Kanayago.parse('117i * 117i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::ImaginaryNode, body.recv)
@@ -76,10 +76,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary_div_opcall
     result = Kanayago.parse('117i / 117i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::ImaginaryNode, body.recv)
@@ -94,10 +94,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary_remainder_opcall
     result = Kanayago.parse('117i % 117i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::ImaginaryNode, body.recv)
@@ -112,10 +112,10 @@ class ParseImaginaryTest < Minitest::Test
   def test_parse_imaginary_call
     result = Kanayago.parse('117i.to_i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::ImaginaryNode, body.recv)

--- a/test/kanayago/parse_in_node_test.rb
+++ b/test/kanayago/parse_in_node_test.rb
@@ -6,7 +6,7 @@ class ParseInNodeTest < Minitest::Test
   def test_parse_in_node_with_array_pattern
     result = Kanayago.parse('case [1, 2]; in [a, b]; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
 
@@ -18,7 +18,7 @@ class ParseInNodeTest < Minitest::Test
   def test_parse_in_node_with_hash_pattern
     result = Kanayago.parse('case {x: 1}; in {x: a}; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     in_node = case3_node.body
 
@@ -29,7 +29,7 @@ class ParseInNodeTest < Minitest::Test
   def test_parse_multiple_in_nodes
     result = Kanayago.parse('case [1, 2]; in [1, x]; in [a, b]; end')
 
-    scope = result
+    scope = result.ast
     case3_node = scope.body
     first_in = case3_node.body
 

--- a/test/kanayago/parse_instance_assignment_node_test.rb
+++ b/test/kanayago/parse_instance_assignment_node_test.rb
@@ -6,7 +6,7 @@ class ParseInstanceAssignmentNodeTest < Minitest::Test
   def test_parse_instance_assignment_node
     result = Kanayago.parse('@var = 117')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::InstanceAssignmentNode, body)
     assert_equal(:@var, body.id)

--- a/test/kanayago/parse_integer_test.rb
+++ b/test/kanayago/parse_integer_test.rb
@@ -6,10 +6,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer
     result = Kanayago.parse('1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IntegerNode, body)
     assert_equal(1, body.val)
@@ -20,10 +20,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_plus_opcall
     result = Kanayago.parse('1 + 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)
@@ -44,10 +44,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_minus_opcall
     result = Kanayago.parse('1 - 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)
@@ -68,10 +68,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_times_opcall
     result = Kanayago.parse('1 * 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)
@@ -92,10 +92,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_div_opcall
     result = Kanayago.parse('1 / 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)
@@ -116,10 +116,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_remainder_opcall
     result = Kanayago.parse('1 % 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)
@@ -140,10 +140,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_call
     result = Kanayago.parse('1.to_i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)
@@ -159,10 +159,10 @@ class ParseIntegerTest < Minitest::Test
   def test_parse_integer_call_with_arg
     result = Kanayago.parse('1.to_i(10)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.recv)

--- a/test/kanayago/parse_iter_test.rb
+++ b/test/kanayago/parse_iter_test.rb
@@ -10,7 +10,7 @@ class ParseIterTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
     assert_instance_of(Kanayago::ScopeNode, body.body)
@@ -22,7 +22,7 @@ class ParseIterTest < Minitest::Test
       [1, 2, 3].map { |x| x * 2 }
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
     refute_nil(body.body)
@@ -36,7 +36,7 @@ class ParseIterTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
   end

--- a/test/kanayago/parse_ivar_test.rb
+++ b/test/kanayago/parse_ivar_test.rb
@@ -6,10 +6,10 @@ class ParseIvarTest < Minitest::Test
   def test_parse_ivar
     result = Kanayago.parse('@kanayago')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::InstanceVariableNode, body)
     assert_equal(:@kanayago, body.vid)

--- a/test/kanayago/parse_kw_arg_test.rb
+++ b/test/kanayago/parse_kw_arg_test.rb
@@ -6,8 +6,8 @@ class ParseKwArgTest < Minitest::Test
   def test_parse_keyword_argument_with_default
     result = Kanayago.parse('def foo(bar: 1); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)

--- a/test/kanayago/parse_lambda_test.rb
+++ b/test/kanayago/parse_lambda_test.rb
@@ -6,8 +6,8 @@ class ParseLambdaTest < Minitest::Test
   def test_parse_lambda_no_args
     result = Kanayago.parse('-> { 42 }')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::LambdaNode, body)
     assert_instance_of(Kanayago::ScopeNode, body.body)
@@ -16,8 +16,8 @@ class ParseLambdaTest < Minitest::Test
   def test_parse_lambda_with_args
     result = Kanayago.parse('->(x) { x * 2 }')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::LambdaNode, body)
     assert_instance_of(Kanayago::ScopeNode, body.body)
@@ -31,8 +31,8 @@ class ParseLambdaTest < Minitest::Test
     RUBY
     result = Kanayago.parse(code)
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::LambdaNode, body)
     assert_instance_of(Kanayago::ScopeNode, body.body)
@@ -42,8 +42,8 @@ class ParseLambdaTest < Minitest::Test
     code = 'lambda do |x| x * 2 end'
     result = Kanayago.parse(code)
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
   end

--- a/test/kanayago/parse_lasgn_test.rb
+++ b/test/kanayago/parse_lasgn_test.rb
@@ -6,10 +6,10 @@ class ParseLasgnTest < Minitest::Test
   def test_parse_lasgn
     result = Kanayago.parse('var = 117')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::LocalAssignmentNode, body)
     assert_equal(:var, body.id)

--- a/test/kanayago/parse_line_node_test.rb
+++ b/test/kanayago/parse_line_node_test.rb
@@ -6,7 +6,7 @@ class ParseLineNodeTest < Minitest::Test
   def test_parse_line_node
     result = Kanayago.parse('__LINE__')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::LineNode, body)
     assert_equal(0, body.lineno)

--- a/test/kanayago/parse_lvar_test.rb
+++ b/test/kanayago/parse_lvar_test.rb
@@ -9,10 +9,10 @@ class ParseLvarTest < Minitest::Test
       p v
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     assert_equal(2, body.size)

--- a/test/kanayago/parse_masgn_test.rb
+++ b/test/kanayago/parse_masgn_test.rb
@@ -6,8 +6,8 @@ class ParseMasgnTest < Minitest::Test
   def test_parse_multiple_assignment
     result = Kanayago.parse('a, b = 1, 2')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    masgn_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    masgn_node = result.ast.body
 
     assert_instance_of(Kanayago::MasgnNode, masgn_node)
     refute_nil(masgn_node.head)
@@ -16,7 +16,7 @@ class ParseMasgnTest < Minitest::Test
   def test_parse_multiple_assignment_with_array
     result = Kanayago.parse('a, b = [1, 2]')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    refute_nil(result.body)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    refute_nil(result.ast.body)
   end
 end

--- a/test/kanayago/parse_match2_node_test.rb
+++ b/test/kanayago/parse_match2_node_test.rb
@@ -6,7 +6,7 @@ class ParseMatch2NodeTest < Minitest::Test
   def test_parse_match2_node
     result = Kanayago.parse('/foo/ =~ "bar"')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::Match2Node, body)
     assert_instance_of(Kanayago::RegexpNode, body.recv)
@@ -17,7 +17,7 @@ class ParseMatch2NodeTest < Minitest::Test
   def test_parse_match2_node_with_captures
     result = Kanayago.parse('/(?<name>\w+)/ =~ "test"')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::Match2Node, body)
     # nd_args should contain capture assignments when named captures exist

--- a/test/kanayago/parse_match3_node_test.rb
+++ b/test/kanayago/parse_match3_node_test.rb
@@ -6,7 +6,7 @@ class ParseMatch3NodeTest < Minitest::Test
   def test_parse_match3_node
     result = Kanayago.parse('"bar" =~ /foo#{1}/')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::Match3Node, body)
     assert_instance_of(Kanayago::DynamicRegexpNode, body.recv)
@@ -17,7 +17,7 @@ class ParseMatch3NodeTest < Minitest::Test
   def test_parse_match3_node_with_variable
     result = Kanayago.parse('x = 1; "test" =~ /pattern#{x}/')
 
-    block = result.body
+    block = result.ast.body
     match3_node = block[1]
 
     assert_instance_of(Kanayago::Match3Node, match3_node)

--- a/test/kanayago/parse_match_node_test.rb
+++ b/test/kanayago/parse_match_node_test.rb
@@ -6,7 +6,7 @@ class ParseMatchNodeTest < Minitest::Test
   def test_parse_match_node
     result = Kanayago.parse('if /hello/ then end')
 
-    scope = result
+    scope = result.ast
     if_node = scope.body
     cond = if_node.cond
 
@@ -18,7 +18,7 @@ class ParseMatchNodeTest < Minitest::Test
   def test_parse_match_node_with_options
     result = Kanayago.parse('if /hello/i then end')
 
-    scope = result
+    scope = result.ast
     if_node = scope.body
     cond = if_node.cond
 

--- a/test/kanayago/parse_module_node_test.rb
+++ b/test/kanayago/parse_module_node_test.rb
@@ -9,7 +9,7 @@ class ParseModuleNodeTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ModuleNode, body)
     assert_instance_of(Kanayago::Colon2Node, body.cpath)
@@ -34,7 +34,7 @@ class ParseModuleNodeTest < Minitest::Test
 
     result = Kanayago.parse(code)
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    refute_nil(result.body)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    refute_nil(result.ast.body)
   end
 end

--- a/test/kanayago/parse_next_test.rb
+++ b/test/kanayago/parse_next_test.rb
@@ -6,7 +6,7 @@ class ParseNextTest < Minitest::Test
   def test_parse_next_basic
     result = Kanayago.parse('loop { next }')
 
-    scope = result
+    scope = result.ast
 
     assert_instance_of(Kanayago::ScopeNode, scope)
 
@@ -27,7 +27,7 @@ class ParseNextTest < Minitest::Test
   def test_parse_next_with_value
     result = Kanayago.parse('loop { next 117 }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
     iter_body = iter.body
     next_node = iter_body.body
@@ -39,7 +39,7 @@ class ParseNextTest < Minitest::Test
   def test_parse_next_with_multiple_values
     result = Kanayago.parse('loop { next 1, 2 }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
     iter_body = iter.body
     next_node = iter_body.body
@@ -52,7 +52,7 @@ class ParseNextTest < Minitest::Test
   def test_parse_next_conditional
     result = Kanayago.parse('loop { next if true }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
     iter_body = iter.body
     if_node = iter_body.body
@@ -68,7 +68,7 @@ class ParseNextTest < Minitest::Test
   def test_parse_next_in_iterator
     result = Kanayago.parse('[1, 2, 3].each { |i| next }')
 
-    scope = result
+    scope = result.ast
     iter = scope.body
 
     assert_instance_of(Kanayago::IterNode, iter)

--- a/test/kanayago/parse_nil_node_test.rb
+++ b/test/kanayago/parse_nil_node_test.rb
@@ -6,7 +6,7 @@ class ParseNilNodeTest < Minitest::Test
   def test_parse_nil_node
     result = Kanayago.parse('nil')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::NilNode, body)
     assert_nil(body.val)

--- a/test/kanayago/parse_nth_ref_test.rb
+++ b/test/kanayago/parse_nth_ref_test.rb
@@ -9,8 +9,8 @@ class ParseNthRefTest < Minitest::Test
       p $1
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     assert_equal(2, body.size)
@@ -31,7 +31,7 @@ class ParseNthRefTest < Minitest::Test
       p $2
     CODE
 
-    body = result.body
+    body = result.ast.body
     second_line = body.last
 
     assert_instance_of(Kanayago::FunctionCallNode, second_line)
@@ -48,7 +48,7 @@ class ParseNthRefTest < Minitest::Test
       p $1, $2, $3
     CODE
 
-    body = result.body
+    body = result.ast.body
     second_line = body.last
 
     assert_instance_of(Kanayago::FunctionCallNode, second_line)
@@ -70,7 +70,7 @@ class ParseNthRefTest < Minitest::Test
       puts "\#{$1}"
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_equal(2, body.size)
 

--- a/test/kanayago/parse_once_test.rb
+++ b/test/kanayago/parse_once_test.rb
@@ -6,7 +6,7 @@ class ParseOnceTest < Minitest::Test
   def test_parse_begin_block
     result = Kanayago.parse('BEGIN { puts "hello" }')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    refute_nil(result.body)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    refute_nil(result.ast.body)
   end
 end

--- a/test/kanayago/parse_op_asgn1_test.rb
+++ b/test/kanayago/parse_op_asgn1_test.rb
@@ -6,8 +6,8 @@ class ParseOpAsgn1Test < Minitest::Test
   def test_parse_op_asgn1_plus
     result = Kanayago.parse('ary[0] += 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignment1Node, body)
     assert_equal(:+, body.mid)
@@ -19,8 +19,8 @@ class ParseOpAsgn1Test < Minitest::Test
   def test_parse_op_asgn1_or
     result = Kanayago.parse('hash[:key] ||= "default"')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignment1Node, body)
     assert_instance_of(Kanayago::VariableCallNode, body.recv)
@@ -29,8 +29,8 @@ class ParseOpAsgn1Test < Minitest::Test
   def test_parse_op_asgn1_and
     result = Kanayago.parse('ary[1] &&= value')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignment1Node, body)
     assert_instance_of(Kanayago::VariableCallNode, body.recv)

--- a/test/kanayago/parse_op_asgn2_test.rb
+++ b/test/kanayago/parse_op_asgn2_test.rb
@@ -6,8 +6,8 @@ class ParseOpAsgn2Test < Minitest::Test
   def test_parse_op_asgn2_plus
     result = Kanayago.parse('obj.attr += 10')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignment2Node, body)
     assert_equal(:+, body.mid)
@@ -19,8 +19,8 @@ class ParseOpAsgn2Test < Minitest::Test
   def test_parse_op_asgn2_minus
     result = Kanayago.parse('obj.count -= 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignment2Node, body)
     assert_equal(:-, body.mid)
@@ -30,8 +30,8 @@ class ParseOpAsgn2Test < Minitest::Test
   def test_parse_op_asgn2_multiply
     result = Kanayago.parse('obj.value *= 2')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignment2Node, body)
     assert_equal(:*, body.mid)

--- a/test/kanayago/parse_op_asgn_and_test.rb
+++ b/test/kanayago/parse_op_asgn_and_test.rb
@@ -6,8 +6,8 @@ class ParseOpAsgnAndTest < Minitest::Test
   def test_parse_op_asgn_and
     result = Kanayago.parse('var &&= 117')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignmentAndNode, body)
     assert_instance_of(Kanayago::LocalVariableNode, body.head)
@@ -17,8 +17,8 @@ class ParseOpAsgnAndTest < Minitest::Test
   def test_parse_op_asgn_and_instance_variable
     result = Kanayago.parse('@ivar &&= "value"')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignmentAndNode, body)
     assert_instance_of(Kanayago::InstanceVariableNode, body.head)

--- a/test/kanayago/parse_op_asgn_or_test.rb
+++ b/test/kanayago/parse_op_asgn_or_test.rb
@@ -6,8 +6,8 @@ class ParseOpAsgnOrTest < Minitest::Test
   def test_parse_op_asgn_or
     result = Kanayago.parse('var ||= 42')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignmentOrNode, body)
     assert_instance_of(Kanayago::LocalVariableNode, body.head)
@@ -17,8 +17,8 @@ class ParseOpAsgnOrTest < Minitest::Test
   def test_parse_op_asgn_or_global_variable
     result = Kanayago.parse('$gvar ||= []')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorAssignmentOrNode, body)
     assert_instance_of(Kanayago::GlobalVariableNode, body.head)

--- a/test/kanayago/parse_op_cdecl_test.rb
+++ b/test/kanayago/parse_op_cdecl_test.rb
@@ -6,8 +6,8 @@ class ParseOpCdeclTest < Minitest::Test
   def test_parse_op_cdecl_plus
     result = Kanayago.parse('Foo::CONST += 100')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorConstantDeclarationNode, body)
     assert_equal(:+, body.aid)
@@ -18,8 +18,8 @@ class ParseOpCdeclTest < Minitest::Test
   def test_parse_op_cdecl_multiply
     result = Kanayago.parse('Bar::MAX_VALUE *= 2')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorConstantDeclarationNode, body)
     assert_equal(:*, body.aid)
@@ -28,8 +28,8 @@ class ParseOpCdeclTest < Minitest::Test
   def test_parse_op_cdecl_scoped
     result = Kanayago.parse('Foo::Bar::CONST += 1')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorConstantDeclarationNode, body)
   end

--- a/test/kanayago/parse_opt_arg_test.rb
+++ b/test/kanayago/parse_opt_arg_test.rb
@@ -6,8 +6,8 @@ class ParseOptArgTest < Minitest::Test
   def test_parse_optional_argument
     result = Kanayago.parse('def foo(a = 1); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)
@@ -16,8 +16,8 @@ class ParseOptArgTest < Minitest::Test
   def test_parse_multiple_optional_arguments
     result = Kanayago.parse('def bar(a = 1, b = 2); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)

--- a/test/kanayago/parse_or_node_test.rb
+++ b/test/kanayago/parse_or_node_test.rb
@@ -6,7 +6,7 @@ class ParseOrNode < Minitest::Test
   def test_parse_or_node
     result = Kanayago.parse('1 || 2')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OrNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.first)

--- a/test/kanayago/parse_post_arg_test.rb
+++ b/test/kanayago/parse_post_arg_test.rb
@@ -6,8 +6,8 @@ class ParsePostArgTest < Minitest::Test
   def test_parse_post_argument
     result = Kanayago.parse('def foo(*args, a); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)
@@ -16,8 +16,8 @@ class ParsePostArgTest < Minitest::Test
   def test_parse_post_arguments_multiple
     result = Kanayago.parse('def bar(*args, a, b); end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    defn = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    defn = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, defn)
     refute_nil(defn.defn.args)

--- a/test/kanayago/parse_postexe_test.rb
+++ b/test/kanayago/parse_postexe_test.rb
@@ -6,8 +6,8 @@ class ParsePostexeTest < Minitest::Test
   def test_parse_end_block
     result = Kanayago.parse('END { puts "goodbye" }')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    postexe_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    postexe_node = result.ast.body
 
     assert_instance_of(Kanayago::PostexeNode, postexe_node)
     refute_nil(postexe_node.body)

--- a/test/kanayago/parse_qcall_test.rb
+++ b/test/kanayago/parse_qcall_test.rb
@@ -8,8 +8,8 @@ class ParseQcallTest < Minitest::Test
       obj&.method_name
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::SafeCallNode, body)
     assert_equal(:method_name, body.mid)
@@ -21,8 +21,8 @@ class ParseQcallTest < Minitest::Test
       obj&.method_name(arg1, arg2)
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::SafeCallNode, body)
     assert_equal(:method_name, body.mid)

--- a/test/kanayago/parse_range_test.rb
+++ b/test/kanayago/parse_range_test.rb
@@ -8,8 +8,8 @@ class ParseRangeTest < Minitest::Test
       1..10
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RangeNode, body)
 
@@ -23,8 +23,8 @@ class ParseRangeTest < Minitest::Test
       1...10
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ExclusiveRangeNode, body)
 
@@ -38,7 +38,7 @@ class ParseRangeTest < Minitest::Test
       x..y
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RangeNode, body)
     assert_instance_of(Kanayago::VariableCallNode, body.beg)
@@ -50,7 +50,7 @@ class ParseRangeTest < Minitest::Test
       a...b
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ExclusiveRangeNode, body)
     assert_instance_of(Kanayago::VariableCallNode, body.beg)

--- a/test/kanayago/parse_rational_test.rb
+++ b/test/kanayago/parse_rational_test.rb
@@ -6,10 +6,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational
     result = Kanayago.parse('117r')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RationalNode, body)
     assert_equal(117r, body.val)
@@ -21,10 +21,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_plus_opcall
     result = Kanayago.parse('117r + 117r')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)
@@ -39,10 +39,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_minus_opcall
     result = Kanayago.parse('117r - 117r')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)
@@ -57,10 +57,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_times_opcall
     result = Kanayago.parse('117r * 117r')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)
@@ -75,10 +75,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_div_opcall
     result = Kanayago.parse('117r / 117r')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)
@@ -93,10 +93,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_remainder_opcall
     result = Kanayago.parse('117r % 117r')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)
@@ -111,10 +111,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_call
     result = Kanayago.parse('117r.to_i')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)
@@ -125,10 +125,10 @@ class ParseRationalTest < Minitest::Test
   def test_parse_rational_call_with_arg
     result = Kanayago.parse('117r.to_i(10)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::CallNode, body)
     assert_instance_of(Kanayago::RationalNode, body.recv)

--- a/test/kanayago/parse_redo_test.rb
+++ b/test/kanayago/parse_redo_test.rb
@@ -5,7 +5,7 @@ require_relative '../test_helper'
 class ParseRedoTest < Minitest::Test
   def test_parse_redo_basic
     result = Kanayago.parse('loop { redo }')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
     iter_body = body.body
@@ -16,7 +16,7 @@ class ParseRedoTest < Minitest::Test
 
   def test_parse_redo_conditional
     result = Kanayago.parse('loop { redo if true }')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
     iter_body = body.body
@@ -28,7 +28,7 @@ class ParseRedoTest < Minitest::Test
 
   def test_parse_redo_in_iterator
     result = Kanayago.parse('3.times { redo }')
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, body)
     iter_body = body.body

--- a/test/kanayago/parse_regexp_node_test.rb
+++ b/test/kanayago/parse_regexp_node_test.rb
@@ -6,7 +6,7 @@ class ParseRegexpNodeTest < Minitest::Test
   def test_parse_regexp_node
     result = Kanayago.parse('/hello/')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RegexpNode, body)
     assert_equal('hello', body.ptr)
@@ -16,7 +16,7 @@ class ParseRegexpNodeTest < Minitest::Test
   def test_parse_regexp_node_with_options
     result = Kanayago.parse('/hello/i')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RegexpNode, body)
     assert_equal('hello', body.ptr)

--- a/test/kanayago/parse_resbody_test.rb
+++ b/test/kanayago/parse_resbody_test.rb
@@ -12,7 +12,7 @@ class ParseRescueBodyTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
     rescue_node = body
 
     assert_instance_of(Kanayago::RescueNode, rescue_node)
@@ -31,7 +31,7 @@ class ParseRescueBodyTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
     rescue_node = body
 
     assert_instance_of(Kanayago::RescueNode, rescue_node)
@@ -53,7 +53,7 @@ class ParseRescueBodyTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
     rescue_node = body
 
     assert_instance_of(Kanayago::RescueNode, rescue_node)
@@ -76,7 +76,7 @@ class ParseRescueBodyTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
     rescue_node = body
 
     assert_instance_of(Kanayago::RescueNode, rescue_node)

--- a/test/kanayago/parse_rescue_test.rb
+++ b/test/kanayago/parse_rescue_test.rb
@@ -12,7 +12,7 @@ class ParseRescueTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RescueNode, body)
     refute_nil(body.head)
@@ -28,7 +28,7 @@ class ParseRescueTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RescueNode, body)
     assert_instance_of(Kanayago::RescueBodyNode, body.resq)
@@ -45,7 +45,7 @@ class ParseRescueTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RescueNode, body)
     refute_nil(body.else)
@@ -62,7 +62,7 @@ class ParseRescueTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RescueNode, body)
     first_resbody = body.resq

--- a/test/kanayago/parse_result_test.rb
+++ b/test/kanayago/parse_result_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class ParseResultTest < Minitest::Test
+  def test_parse_result_with_valid_code
+    result = Kanayago.parse('1 + 1')
+
+    assert_instance_of(Kanayago::ParseResult, result)
+    assert_predicate(result, :valid?)
+    refute_predicate(result, :invalid?)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    refute_kind_of(SyntaxError, result.error)
+  end
+
+  def test_parse_result_with_syntax_error
+    code = <<~RUBY
+      def foo
+        x = 1 +
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ParseResult, result)
+    refute_predicate(result, :valid?)
+    assert_predicate(result, :invalid?)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_instance_of(SyntaxError, result.error)
+  end
+
+  def test_parse_result_error_message
+    code = <<~RUBY
+      def foo
+        x = 1 +
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(SyntaxError, result.error)
+    assert_match(/syntax error/, result.error.message)
+    assert_match(/unexpected 'end'/, result.error.message)
+  end
+
+  def test_parse_result_ast_accessor
+    result = Kanayago.parse('x = 1')
+
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
+    assert_instance_of(Kanayago::LocalAssignmentNode, result.ast.body)
+  end
+
+  def test_parse_result_error_accessor_with_valid_code
+    result = Kanayago.parse('x = 1')
+
+    # Valid code should not have SyntaxError
+    refute_kind_of(SyntaxError, result.error)
+  end
+
+  def test_parse_result_with_multiple_syntax_errors
+    code = <<~RUBY
+      def foo
+        x = 1 +
+        y = 2 *
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ParseResult, result)
+    assert_predicate(result, :invalid?)
+    assert_instance_of(SyntaxError, result.error)
+    # First error should be reported
+    assert_match(/syntax error/, result.error.message)
+  end
+
+  def test_parse_result_with_unclosed_string
+    code = '"unclosed string'
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ParseResult, result)
+    assert_predicate(result, :invalid?)
+    assert_instance_of(SyntaxError, result.error)
+    assert_match(/unterminated string/, result.error.message)
+  end
+
+  def test_parse_result_with_unexpected_token
+    code = 'def foo end end'
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Kanayago::ParseResult, result)
+    assert_predicate(result, :invalid?)
+    assert_instance_of(SyntaxError, result.error)
+    assert_match(/syntax error/, result.error.message)
+  end
+
+  def test_parse_result_valid_method_with_simple_expression
+    result = Kanayago.parse('1')
+
+    assert_predicate(result, :valid?)
+    assert_instance_of(Kanayago::IntegerNode, result.ast.body)
+  end
+
+  def test_parse_result_invalid_method_with_missing_expression
+    code = <<~RUBY
+      if
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_predicate(result, :invalid?)
+    assert_instance_of(SyntaxError, result.error)
+  end
+
+  def test_parse_result_with_empty_code
+    result = Kanayago.parse('')
+
+    assert_instance_of(Kanayago::ParseResult, result)
+    assert_predicate(result, :valid?)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+  end
+end

--- a/test/kanayago/parse_retry_test.rb
+++ b/test/kanayago/parse_retry_test.rb
@@ -12,7 +12,7 @@ class ParseRetryTest < Minitest::Test
       end
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::RescueNode, body)
 

--- a/test/kanayago/parse_return_node_test.rb
+++ b/test/kanayago/parse_return_node_test.rb
@@ -8,7 +8,7 @@ class ParseReturnNode < Minitest::Test
       return 117
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ReturnNode, body)
     assert_instance_of(Kanayago::IntegerNode, body.statements)
@@ -19,7 +19,7 @@ class ParseReturnNode < Minitest::Test
       return 117, 34
     CODE
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ReturnNode, body)
     assert_instance_of(Kanayago::ListNode, body.statements)

--- a/test/kanayago/parse_sclass_test.rb
+++ b/test/kanayago/parse_sclass_test.rb
@@ -11,8 +11,8 @@ class ParseSclassTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::SingletonClassNode, body)
     assert_instance_of(Kanayago::SelfNode, body.recv)

--- a/test/kanayago/parse_self_node_test.rb
+++ b/test/kanayago/parse_self_node_test.rb
@@ -6,7 +6,7 @@ class ParseSelfNodeTest < Minitest::Test
   def test_parse_true_node
     result = Kanayago.parse('self')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::SelfNode, body)
     assert_equal(1, body.state)

--- a/test/kanayago/parse_splat_test.rb
+++ b/test/kanayago/parse_splat_test.rb
@@ -6,8 +6,8 @@ class ParseSplatTest < Minitest::Test
   def test_parse_splat_in_method_call
     result = Kanayago.parse('foo(*args)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     splat_node = call_node.args
@@ -19,8 +19,8 @@ class ParseSplatTest < Minitest::Test
   def test_parse_splat_with_multiple_args
     result = Kanayago.parse('bar(1, *rest, 2)')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    call_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    call_node = result.ast.body
 
     assert_instance_of(Kanayago::FunctionCallNode, call_node)
     refute_nil(call_node.args)
@@ -29,8 +29,8 @@ class ParseSplatTest < Minitest::Test
   def test_parse_splat_in_send
     result = Kanayago.parse('[1, 2].each { |x| puts(*x) }')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    iter_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    iter_node = result.ast.body
 
     assert_instance_of(Kanayago::IterNode, iter_node)
   end

--- a/test/kanayago/parse_string_test.rb
+++ b/test/kanayago/parse_string_test.rb
@@ -6,10 +6,10 @@ class ParseStringTest < Minitest::Test
   def test_parse_string
     result = Kanayago.parse('"Kanayago"')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::StringNode, body)
     assert_equal('Kanayago', body.ptr)
@@ -21,10 +21,10 @@ class ParseStringTest < Minitest::Test
   def test_parse_string_plus_opcall
     result = Kanayago.parse('"Kanayago" + ".parse"')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::StringNode, body.recv)
@@ -39,10 +39,10 @@ class ParseStringTest < Minitest::Test
   def test_parse_string_times_opcall
     result = Kanayago.parse('"Kanayago" * 2')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::OperatorCallNode, body)
     assert_instance_of(Kanayago::StringNode, body.recv)

--- a/test/kanayago/parse_super_test.rb
+++ b/test/kanayago/parse_super_test.rb
@@ -18,8 +18,8 @@ class ParseSuperTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     child_class = body[1]

--- a/test/kanayago/parse_sym_test.rb
+++ b/test/kanayago/parse_sym_test.rb
@@ -6,10 +6,10 @@ class ParseSymTest < Minitest::Test
   def test_parse_sym
     result = Kanayago.parse(':kanayago')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::SymbolNode, body)
     assert_equal('kanayago', body.ptr)

--- a/test/kanayago/parse_true_node_test.rb
+++ b/test/kanayago/parse_true_node_test.rb
@@ -6,7 +6,7 @@ class ParseTrueNodeTest < Minitest::Test
   def test_parse_true_node
     result = Kanayago.parse('true')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::TrueNode, body)
     assert(body.val)

--- a/test/kanayago/parse_undef_node_test.rb
+++ b/test/kanayago/parse_undef_node_test.rb
@@ -6,7 +6,7 @@ class ParseUndefNodeTest < Minitest::Test
   def test_parse_undef_node
     result = Kanayago.parse('undef :send')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::UndefNode, body)
     assert_instance_of(Array, body.undefs)

--- a/test/kanayago/parse_unless_test.rb
+++ b/test/kanayago/parse_unless_test.rb
@@ -11,10 +11,10 @@ class ParseUnlessTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     line = body[0]
 

--- a/test/kanayago/parse_until_node_test.rb
+++ b/test/kanayago/parse_until_node_test.rb
@@ -12,7 +12,7 @@ class ParseUntilNodeTest < Minitest::Test
       end
     CODE
 
-    line = result.body.last
+    line = result.ast.body.last
 
     assert_instance_of(Kanayago::UntilNode, line)
     assert_equal(1, line.state)

--- a/test/kanayago/parse_valias_node_test.rb
+++ b/test/kanayago/parse_valias_node_test.rb
@@ -6,7 +6,7 @@ class ParseValiasNodeTest < Minitest::Test
   def test_parse_valias_node
     result = Kanayago.parse('alias $v $g')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ValiasNode, body)
     assert_equal(:$v, body.alias)

--- a/test/kanayago/parse_vcall_test.rb
+++ b/test/kanayago/parse_vcall_test.rb
@@ -6,10 +6,10 @@ class ParseVcallTest < Minitest::Test
   def test_parse_vcall
     result = Kanayago.parse('foo')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::VariableCallNode, body)
     assert_equal(:foo, body.mid)
@@ -18,10 +18,10 @@ class ParseVcallTest < Minitest::Test
   def test_parse_vcall_with_underscore
     result = Kanayago.parse('foo_bar')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    assert_nil(result.args)
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    assert_nil(result.ast.args)
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::VariableCallNode, body)
     assert_equal(:foo_bar, body.mid)

--- a/test/kanayago/parse_when_test.rb
+++ b/test/kanayago/parse_when_test.rb
@@ -11,7 +11,7 @@ class ParseWhenTest < Minitest::Test
       end
     CODE
 
-    body = result.body.body # CaseNode -> WhenNode
+    body = result.ast.body.body # CaseNode -> WhenNode
 
     assert_instance_of(Kanayago::WhenNode, body)
 
@@ -30,7 +30,7 @@ class ParseWhenTest < Minitest::Test
       end
     CODE
 
-    body = result.body.body
+    body = result.ast.body.body
 
     assert_instance_of(Kanayago::WhenNode, body)
     assert_instance_of(Kanayago::ListNode, body.head)
@@ -46,7 +46,7 @@ class ParseWhenTest < Minitest::Test
       end
     CODE
 
-    first_when = result.body.body
+    first_when = result.ast.body.body
 
     assert_instance_of(Kanayago::WhenNode, first_when)
 

--- a/test/kanayago/parse_while_node_test.rb
+++ b/test/kanayago/parse_while_node_test.rb
@@ -12,8 +12,8 @@ class ParseWhileNodeTest < Minitest::Test
       end
     CODE
 
-    result.body
-    line = result.body.last
+    result.ast.body
+    line = result.ast.body.last
 
     assert_instance_of(Kanayago::WhileNode, line)
     assert_equal(1, line.state)

--- a/test/kanayago/parse_yield_test.rb
+++ b/test/kanayago/parse_yield_test.rb
@@ -6,8 +6,8 @@ class ParseYieldTest < Minitest::Test
   def test_parse_yield_no_args
     result = Kanayago.parse('def foo; yield; end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    definition_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    definition_node = result.ast.body
 
     assert_instance_of(Kanayago::DefinitionNode, definition_node)
     scope_node = definition_node.defn
@@ -22,8 +22,8 @@ class ParseYieldTest < Minitest::Test
   def test_parse_yield_single_arg
     result = Kanayago.parse('def foo; yield 42; end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    definition_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    definition_node = result.ast.body
     scope_node = definition_node.defn
     yield_node = scope_node.body
 
@@ -35,8 +35,8 @@ class ParseYieldTest < Minitest::Test
   def test_parse_yield_multiple_args
     result = Kanayago.parse('def foo; yield 1, 2, 3; end')
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    definition_node = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    definition_node = result.ast.body
     scope_node = definition_node.defn
     yield_node = scope_node.body
 

--- a/test/kanayago/parse_zero_list_test.rb
+++ b/test/kanayago/parse_zero_list_test.rb
@@ -6,7 +6,7 @@ class ParseZeroListTest < Minitest::Test
   def test_parse_zero_list
     result = Kanayago.parse('[]')
 
-    body = result.body
+    body = result.ast.body
 
     assert_instance_of(Kanayago::ZeroListNode, body)
     assert_equal(0, body.len)

--- a/test/kanayago/parse_zsuper_test.rb
+++ b/test/kanayago/parse_zsuper_test.rb
@@ -18,8 +18,8 @@ class ParseZsuperTest < Minitest::Test
       end
     CODE
 
-    assert_instance_of(Kanayago::ScopeNode, result)
-    body = result.body
+    assert_instance_of(Kanayago::ScopeNode, result.ast)
+    body = result.ast.body
 
     assert_instance_of(Kanayago::BlockNode, body)
     child_class = body[1]


### PR DESCRIPTION
Introduce `Kanayago::ParseResult` class to provide both AST and error
information from parsing results. This enables error-tolerant parsing
where syntax errors no longer cause crashes, instead returning both
partial AST and error details.

Key changes:
- Add ParseResult class with ast, error, valid?, and invalid? methods
- Enable error_tolerant mode via rb_ruby_parser_error_tolerant flag
- Implement rb_syntax_error_append to handle syntax errors gracefully
- Fix Qfalse and frozen message handling in error creation
- Move error_buffer accessor to patch files for better maintainability
- Update all 93 test files to use result.ast instead of direct access
- Document breaking API changes in CHANGELOG

This resolves parser crashes on syntax errors and provides a foundation
for better error reporting and recovery in future releases.
