### PR TITLE
Add CLI mode for syntax checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add CLI mode for syntax checking
+  - `kanayago check 'code'` - Check Ruby code syntax directly
+  - `kanayago check --file FILE` or `-f FILE` - Check syntax of Ruby file
+  - Output "Syntax valid" for valid syntax, "Syntax invalid" for invalid syntax
+  - Exit with code 0 for valid syntax, 1 for invalid syntax or errors
 - Add `ParseResult` class to wrap AST and error information
   - `ParseResult#ast` - Returns the parsed AST (ScopeNode)
   - `ParseResult#error` - Returns SyntaxError object if syntax error occurred, false otherwise

--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ gem install pkg/kanayago-0.4.1.gem
 
 ## Usage
 
+### Command Line Interface
+
+Kanayago provides a CLI for syntax checking:
+
+```bash
+# Check Ruby code directly
+$ kanayago check 'p 117'
+Syntax valid
+
+# Check Ruby code with syntax error
+$ kanayago check 'def foo'
+Syntax invalid
+
+# Check a Ruby file
+$ kanayago check --file test.rb
+Syntax valid
+
+# Or use the short option
+$ kanayago check -f test.rb
+Syntax valid
+```
+
+The CLI exits with code 0 for valid syntax and code 1 for invalid syntax or errors.
+
+### Ruby API
+
 ```ruby
 require 'kanayago/kanayago'
 

--- a/exe/kanayago
+++ b/exe/kanayago
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'kanayago'
+require 'kanayago/cli'
+
+Kanayago::CLI.start(ARGV)

--- a/lib/kanayago/cli.rb
+++ b/lib/kanayago/cli.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module Kanayago
+  class CLI
+    def self.start(argv)
+      new(argv).run
+    end
+
+    def initialize(argv)
+      @argv = argv
+      @file = nil
+    end
+
+    def run
+      if @argv.empty?
+        puts "Usage: kanayago check 'code' or kanayago check --file FILE"
+        exit 1
+      end
+
+      command = @argv.shift
+
+      case command
+      when 'check'
+        check_command
+      else
+        puts "Unknown command: #{command}"
+        puts "Usage: kanayago check 'code' or kanayago check --file FILE"
+        exit 1
+      end
+    end
+
+    private
+
+    def check_command
+      parse_options
+
+      if @file
+        check_file(@file)
+      elsif @argv.empty?
+        puts 'Error: Please provide Ruby code or use --file option'
+        exit 1
+      else
+        code = @argv.join(' ')
+        check_code(code)
+      end
+    end
+
+    def parse_options
+      OptionParser.new do |opts|
+        opts.banner = "Usage: kanayago check [options] 'code'"
+
+        opts.on('-f FILE', '--file FILE', 'Check syntax of Ruby file') do |file|
+          @file = file
+        end
+
+        opts.on('-h', '--help', 'Show this message') do
+          puts opts
+          exit
+        end
+      end.parse!(@argv)
+    end
+
+    def check_code(code)
+      result = Kanayago.parse(code)
+
+      if result.valid?
+        puts 'Syntax valid'
+        exit 0
+      else
+        puts 'Syntax invalid'
+        exit 1
+      end
+    end
+
+    def check_file(file_path)
+      unless File.exist?(file_path)
+        puts "Error: File not found: #{file_path}"
+        exit 1
+      end
+
+      code = File.read(file_path)
+      check_code(code)
+    rescue StandardError => e
+      puts "Error: #{e.message}"
+      exit 1
+    end
+  end
+end

--- a/test/kanayago/cli_test.rb
+++ b/test/kanayago/cli_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'tempfile'
+
+module Kanayago
+  class CLITest < Minitest::Test
+    def test_check_valid_code
+      output = capture_output do
+        Kanayago::CLI.start(['check', 'p 117'])
+      rescue SystemExit => e
+        assert_equal 0, e.status
+      end
+
+      assert_match(/Syntax valid/, output)
+    end
+
+    def test_check_invalid_code
+      output = capture_output do
+        Kanayago::CLI.start(['check', 'def foo'])
+      rescue SystemExit => e
+        assert_equal 1, e.status
+      end
+
+      assert_match(/Syntax invalid/, output)
+    end
+
+    def test_check_file_with_valid_syntax
+      Tempfile.create(['test', '.rb']) do |file|
+        file.write('p 117')
+        file.flush
+
+        output = capture_output do
+          Kanayago::CLI.start(['check', '--file', file.path])
+        rescue SystemExit => e
+          assert_equal 0, e.status
+        end
+
+        assert_match(/Syntax valid/, output)
+      end
+    end
+
+    def test_check_file_with_invalid_syntax
+      Tempfile.create(['test', '.rb']) do |file|
+        file.write('def foo')
+        file.flush
+
+        output = capture_output do
+          Kanayago::CLI.start(['check', '--file', file.path])
+        rescue SystemExit => e
+          assert_equal 1, e.status
+        end
+
+        assert_match(/Syntax invalid/, output)
+      end
+    end
+
+    def test_check_file_short_option
+      Tempfile.create(['test', '.rb']) do |file|
+        file.write('p 117')
+        file.flush
+
+        output = capture_output do
+          Kanayago::CLI.start(['check', '-f', file.path])
+        rescue SystemExit => e
+          assert_equal 0, e.status
+        end
+
+        assert_match(/Syntax valid/, output)
+      end
+    end
+
+    def test_check_nonexistent_file
+      output = capture_output do
+        Kanayago::CLI.start(['check', '--file', 'nonexistent.rb'])
+      rescue SystemExit => e
+        assert_equal 1, e.status
+      end
+
+      assert_match(/File not found/, output)
+    end
+
+    private
+
+    def capture_output
+      original_stdout = $stdout
+      $stdout = StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = original_stdout
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../lib/kanayago'
+require_relative '../lib/kanayago/cli'
 
 require 'minitest/autorun'


### PR DESCRIPTION
This commit adds a command-line interface to Kanayago for checking Ruby code syntax.

- Add exe/kanayago executable as CLI entry point
- Add Kanayago::CLI class with OptionParser for argument handling
- Support direct code checking: kanayago check 'code'
- Support file checking: kanayago check --file FILE or -f FILE
- Output "Syntax valid" for valid syntax, "Syntax invalid" for invalid
- Exit with code 0 for valid syntax, 1 for invalid syntax or errors
- Add comprehensive CLI tests in test/kanayago/cli_test.rb
- Update README.md with CLI usage examples
- Update CHANGELOG.md with new CLI feature

The CLI leverages the existing Kanayago.parse API and ParseResult class to provide a simple syntax checking tool.
