### PR TITLE
Add LSP mode for real-time syntax checking in editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add LSP (Language Server Protocol) mode
+  - `kanayago --lsp` - Start LSP server for editor integration
+  - Provides real-time syntax error diagnostics via LSP protocol
+  - Supports `textDocument/didOpen`, `didChange`, `didClose` notifications
+  - Publishes diagnostics with `textDocument/publishDiagnostics`
+  - Compatible with LSP-compliant editors (VSCode, etc.)
+  - Add `language_server-protocol` gem dependency (~> 3.17.0)
 - Add CLI mode for syntax checking
   - `kanayago check 'code'` - Check Ruby code syntax directly
   - `kanayago check --file FILE` or `-f FILE` - Check syntax of Ruby file

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     kanayago (0.4.1)
+      language_server-protocol (~> 3.17.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,51 @@ gem install pkg/kanayago-0.4.1.gem
 
 ## Usage
 
+### Language Server Protocol (LSP) Mode
+
+Kanayago provides LSP server support for real-time syntax checking in your editor:
+
+```bash
+# Start LSP server
+$ kanayago --lsp
+```
+
+This starts an LSP server that communicates via stdin/stdout. You can integrate it with LSP-compliant editors like VSCode, Vim, Emacs, etc.
+
+#### VSCode Integration Example
+
+Create or modify `.vscode/settings.json`:
+
+```json
+{
+  "ruby.lsp.enabled": false,
+  "ruby.languageServer": "kanayago-lsp",
+  "ruby.languageServerPath": "kanayago",
+  "ruby.languageServerArgs": ["--lsp"]
+}
+```
+
+Now VSCode will show syntax errors in real-time as you type Ruby code.
+
+#### Vim/Neovim with coc.nvim Integration Example
+
+Add the following to your `coc-settings.json` (`:CocConfig` in Vim):
+
+```json
+{
+  "languageserver": {
+    "kanayago": {
+      "command": "kanayago",
+      "args": ["--lsp"],
+      "filetypes": ["ruby"],
+      "rootPatterns": ["Gemfile", ".git"]
+    }
+  }
+}
+```
+
+Now Vim/Neovim with coc.nvim will show syntax errors in real-time as you edit Ruby files.
+
 ### Command Line Interface
 
 Kanayago provides a CLI for syntax checking:

--- a/kanayago.gemspec
+++ b/kanayago.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency 'language_server-protocol', '~> 3.17.0'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/kanayago/cli.rb
+++ b/lib/kanayago/cli.rb
@@ -11,11 +11,21 @@ module Kanayago
     def initialize(argv)
       @argv = argv
       @file = nil
+      @lsp_mode = false
     end
 
     def run
+      # Check for --lsp flag first
+      parse_global_options
+
+      if @lsp_mode
+        start_lsp_server
+        return
+      end
+
       if @argv.empty?
         puts "Usage: kanayago check 'code' or kanayago check --file FILE"
+        puts '       kanayago --lsp (start LSP server)'
         exit 1
       end
 
@@ -27,11 +37,26 @@ module Kanayago
       else
         puts "Unknown command: #{command}"
         puts "Usage: kanayago check 'code' or kanayago check --file FILE"
+        puts '       kanayago --lsp (start LSP server)'
         exit 1
       end
     end
 
     private
+
+    def parse_global_options
+      # Check for --lsp flag without modifying @argv for other options
+      return unless @argv.include?('--lsp')
+
+      @lsp_mode = true
+      @argv.delete('--lsp')
+    end
+
+    def start_lsp_server
+      require_relative 'lsp'
+      server = Kanayago::LSP::Server.new
+      server.start
+    end
 
     def check_command
       parse_options

--- a/lib/kanayago/lsp.rb
+++ b/lib/kanayago/lsp.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'lsp/server'
+require_relative 'lsp/diagnostics'
+
+module Kanayago
+  # Language Server Protocol support for Kanayago
+  module LSP
+  end
+end

--- a/lib/kanayago/lsp/diagnostics.rb
+++ b/lib/kanayago/lsp/diagnostics.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'language_server-protocol'
+
+module Kanayago
+  module LSP
+    # Provides diagnostics for Ruby source code using Kanayago parser
+    class DiagnosticsProvider
+      def analyze(source)
+        diagnostics = []
+
+        result = Kanayago.parse(source)
+
+        if result.invalid?
+          # Extract error information from SyntaxError
+          error = result.error
+          diagnostic = create_diagnostic(error)
+          diagnostics << diagnostic
+        end
+
+        diagnostics
+      end
+
+      private
+
+      def create_diagnostic(error)
+        # Try to extract line and column from error message
+        # SyntaxError message format: "syntax error, unexpected ..."
+        # or with location: "(eval):2: syntax error, unexpected ..."
+        range = extract_range_from_error(error)
+
+        {
+          range: range,
+          severity: LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR,
+          source: 'Kanayago',
+          message: error.message
+        }
+      end
+
+      def extract_range_from_error(error)
+        # Try to extract line number from error message
+        # Format: "(eval):LINE: message" or just "message"
+        message = error.message
+
+        if message =~ /\(eval\):(\d+):/
+          line = ::Regexp.last_match(1).to_i - 1 # Convert to 0-based
+          {
+            start: { line: line, character: 0 },
+            end: { line: line, character: 0 }
+          }
+        else
+          # Default to line 0 if we can't extract line number
+          {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/kanayago/lsp/server.rb
+++ b/lib/kanayago/lsp/server.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'language_server-protocol'
+require_relative 'diagnostics'
+
+module Kanayago
+  module LSP
+    # Language Server Protocol server for Kanayago
+    class Server
+      def initialize(input: $stdin, output: $stdout)
+        @input = input
+        @output = output
+        @writer = LanguageServer::Protocol::Transport::Io::Writer.new(@output)
+        @reader = LanguageServer::Protocol::Transport::Io::Reader.new(@input)
+        @diagnostics = DiagnosticsProvider.new
+        @documents = {} # URI => content mapping
+      end
+
+      def start
+        @reader.read do |request|
+          handle_request(request)
+        end
+      end
+
+      private
+
+      def handle_request(request) # rubocop:disable Metrics/CyclomaticComplexity
+        case request[:method]
+        when 'initialize'
+          handle_initialize(request)
+        when 'initialized'
+          # Client notification, no response needed
+        when 'shutdown'
+          handle_shutdown(request)
+        when 'exit'
+          exit(0)
+        when 'textDocument/didOpen'
+          handle_did_open(request)
+        when 'textDocument/didChange'
+          handle_did_change(request)
+        when 'textDocument/didClose'
+          handle_did_close(request)
+        else
+          # Unsupported method
+          send_response(request[:id], nil) if request[:id]
+        end
+      end
+
+      def handle_initialize(request)
+        result = {
+          capabilities: {
+            textDocumentSync: {
+              openClose: true,
+              change: LanguageServer::Protocol::Constant::TextDocumentSyncKind::FULL
+            }
+          },
+          serverInfo: {
+            name: 'Kanayago LSP',
+            version: Kanayago::VERSION
+          }
+        }
+        send_response(request[:id], result)
+      end
+
+      def handle_shutdown(request)
+        send_response(request[:id], nil)
+      end
+
+      def handle_did_open(request)
+        params = request[:params]
+        uri = params[:textDocument][:uri]
+        text = params[:textDocument][:text]
+
+        @documents[uri] = text
+        publish_diagnostics(uri, text)
+      end
+
+      def handle_did_change(request)
+        params = request[:params]
+        uri = params[:textDocument][:uri]
+
+        # FULL sync: get entire content
+        text = params[:contentChanges][0][:text]
+
+        @documents[uri] = text
+        publish_diagnostics(uri, text)
+      end
+
+      def handle_did_close(request)
+        params = request[:params]
+        uri = params[:textDocument][:uri]
+
+        @documents.delete(uri)
+        # Clear diagnostics
+        publish_diagnostics(uri, nil)
+      end
+
+      def publish_diagnostics(uri, text)
+        diagnostics = text ? @diagnostics.analyze(text) : []
+
+        notification = {
+          method: 'textDocument/publishDiagnostics',
+          params: {
+            uri: uri,
+            diagnostics: diagnostics
+          }
+        }
+
+        send_notification(notification)
+      end
+
+      def send_response(id, result)
+        response = {
+          jsonrpc: '2.0',
+          id: id,
+          result: result
+        }
+        @writer.write(response)
+      end
+
+      def send_notification(notification)
+        message = {
+          jsonrpc: '2.0',
+          method: notification[:method],
+          params: notification[:params]
+        }
+        @writer.write(message)
+      end
+    end
+  end
+end

--- a/test/kanayago/lsp/diagnostics_test.rb
+++ b/test/kanayago/lsp/diagnostics_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+class DiagnosticsTest < Minitest::Test
+  def setup
+    @provider = Kanayago::LSP::DiagnosticsProvider.new
+  end
+
+  def test_no_diagnostics_for_valid_code
+    source = 'def foo; end'
+    diagnostics = @provider.analyze(source)
+
+    assert_empty diagnostics
+  end
+
+  def test_diagnostics_for_syntax_error
+    source = 'def foo'
+    diagnostics = @provider.analyze(source)
+
+    assert_equal 1, diagnostics.length
+
+    diagnostic = diagnostics.first
+
+    assert_equal LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR,
+                 diagnostic[:severity]
+    assert_equal 'Kanayago', diagnostic[:source]
+    assert_match(/syntax error/, diagnostic[:message])
+  end
+
+  def test_diagnostics_for_incomplete_class
+    source = 'class Foo'
+    diagnostics = @provider.analyze(source)
+
+    refute_empty diagnostics
+  end
+
+  def test_diagnostics_for_complex_error
+    source = <<~RUBY
+      class Foo
+        def bar
+          if condition
+        end
+      end
+    RUBY
+
+    diagnostics = @provider.analyze(source)
+
+    refute_empty diagnostics
+  end
+
+  def test_diagnostics_for_complex_valid_code
+    source = <<~RUBY
+      class MyClass
+        def initialize(name)
+          @name = name
+        end
+
+        def greet
+          puts "Hello, \#{@name}!"
+        end
+      end
+    RUBY
+
+    diagnostics = @provider.analyze(source)
+
+    assert_empty diagnostics
+  end
+
+  def test_diagnostic_range_extraction
+    source = 'def foo'
+    diagnostics = @provider.analyze(source)
+
+    assert_equal 1, diagnostics.length
+
+    diagnostic = diagnostics.first
+
+    assert diagnostic[:range]
+    assert diagnostic[:range][:start]
+    assert diagnostic[:range][:end]
+    assert_kind_of Integer, diagnostic[:range][:start][:line]
+    assert_kind_of Integer, diagnostic[:range][:start][:character]
+  end
+end

--- a/test/kanayago/lsp/server_test.rb
+++ b/test/kanayago/lsp/server_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+require 'stringio'
+require 'json'
+
+class LSPServerTest < Minitest::Test
+  def setup
+    @input = StringIO.new
+    @output = StringIO.new
+    @server = Kanayago::LSP::Server.new(input: @input, output: @output)
+  end
+
+  def test_initialize_request
+    request = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        capabilities: {}
+      }
+    }
+
+    # Handle request manually
+    @server.send(:handle_request, request)
+
+    # Check output
+    @output.rewind
+    response_header = @output.read
+
+    assert_match(/Content-Length:/, response_header)
+  end
+
+  def test_shutdown_request
+    request = {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'shutdown'
+    }
+
+    @server.send(:handle_request, request)
+
+    @output.rewind
+    response_header = @output.read
+
+    assert_match(/Content-Length:/, response_header)
+  end
+
+  def test_did_open_notification
+    request = {
+      jsonrpc: '2.0',
+      method: 'textDocument/didOpen',
+      params: {
+        textDocument: {
+          uri: 'file:///test.rb',
+          text: 'def foo; end'
+        }
+      }
+    }
+
+    @server.send(:handle_request, request)
+
+    @output.rewind
+    response = @output.read
+
+    # Should publish diagnostics
+    assert_match(%r{textDocument/publishDiagnostics}, response)
+  end
+
+  def test_did_change_notification
+    # First open the document
+    open_request = {
+      jsonrpc: '2.0',
+      method: 'textDocument/didOpen',
+      params: {
+        textDocument: {
+          uri: 'file:///test.rb',
+          text: 'def foo; end'
+        }
+      }
+    }
+
+    @server.send(:handle_request, open_request)
+    @output.truncate(0)
+    @output.rewind
+
+    # Then change it
+    change_request = {
+      jsonrpc: '2.0',
+      method: 'textDocument/didChange',
+      params: {
+        textDocument: {
+          uri: 'file:///test.rb'
+        },
+        contentChanges: [
+          { text: 'def bar; end' }
+        ]
+      }
+    }
+
+    @server.send(:handle_request, change_request)
+
+    @output.rewind
+    response = @output.read
+
+    # Should publish diagnostics again
+    assert_match(%r{textDocument/publishDiagnostics}, response)
+  end
+
+  def test_did_close_notification
+    # First open the document
+    open_request = {
+      jsonrpc: '2.0',
+      method: 'textDocument/didOpen',
+      params: {
+        textDocument: {
+          uri: 'file:///test.rb',
+          text: 'def foo; end'
+        }
+      }
+    }
+
+    @server.send(:handle_request, open_request)
+    @output.truncate(0)
+    @output.rewind
+
+    # Then close it
+    close_request = {
+      jsonrpc: '2.0',
+      method: 'textDocument/didClose',
+      params: {
+        textDocument: {
+          uri: 'file:///test.rb'
+        }
+      }
+    }
+
+    @server.send(:handle_request, close_request)
+
+    @output.rewind
+    response = @output.read
+
+    # Should publish empty diagnostics
+    assert_match(%r{textDocument/publishDiagnostics}, response)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,5 +2,7 @@
 
 require_relative '../lib/kanayago'
 require_relative '../lib/kanayago/cli'
+require_relative '../lib/kanayago/lsp/server'
+require_relative '../lib/kanayago/lsp/diagnostics'
 
 require 'minitest/autorun'


### PR DESCRIPTION
This commit implements Language Server Protocol (LSP) support, enabling real-time syntax error diagnostics in LSP-compliant editors like VSCode, Vim/Neovim with coc.nvim, Emacs, and others.

Changes:
- Add `kanayago --lsp` flag to start LSP server
- Implement LSP server with JSON-RPC 2.0 protocol support
- Add diagnostics provider using existing ParseResult API
- Support textDocument/didOpen, didChange, didClose notifications
- Publish diagnostics via textDocument/publishDiagnostics
- Add language_server-protocol gem dependency (~> 3.17.0)
- Add comprehensive tests for LSP functionality (11 new tests)
- Update README with VSCode and Vim/coc.nvim integration examples
- Update CHANGELOG with LSP mode documentation

The implementation leverages Kanayago's existing error-tolerant parser and ParseResult API, providing immediate feedback on syntax errors as users type Ruby code in their editor.
