### PR TITLE
Fix LSP diagnostics to report accurate error line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix LSP diagnostics to report accurate error line numbers
+  - Update error message pattern matching to support both `main:LINE:` and `(eval):LINE:` formats
+  - Remove incorrect `-1` offset that was causing errors to be reported one line above the actual error location
+  - Parser already returns 0-based line numbers, matching LSP protocol requirements
+  - Clean up error messages by removing redundant `main:LINE:` prefix from diagnostic messages
+  - Add comprehensive test cases for error line detection in multi-line source code
+
 ## [0.5.0]
 
 ### Added

--- a/lib/kanayago/lsp/diagnostics.rb
+++ b/lib/kanayago/lsp/diagnostics.rb
@@ -33,17 +33,17 @@ module Kanayago
           range: range,
           severity: LanguageServer::Protocol::Constant::DiagnosticSeverity::ERROR,
           source: 'Kanayago',
-          message: error.message
+          message: error.message.sub(/main:\d+:\s*/, '')
         }
       end
 
       def extract_range_from_error(error)
         # Try to extract line number from error message
-        # Format: "(eval):LINE: message" or just "message"
+        # Format: "main:LINE: message" or "(eval):LINE: message" or just "message"
         message = error.message
 
-        if message =~ /\(eval\):(\d+):/
-          line = ::Regexp.last_match(1).to_i - 1 # Convert to 0-based
+        if message =~ /(?:main|\(eval\)):(\d+):/
+          line = ::Regexp.last_match(1).to_i # Already 0-based or use as-is
           {
             start: { line: line, character: 0 },
             end: { line: line, character: 0 }

--- a/test/kanayago/lsp/diagnostics_test.rb
+++ b/test/kanayago/lsp/diagnostics_test.rb
@@ -81,4 +81,39 @@ class DiagnosticsTest < Minitest::Test
     assert_kind_of Integer, diagnostic[:range][:start][:line]
     assert_kind_of Integer, diagnostic[:range][:start][:character]
   end
+
+  def test_error_on_specific_line
+    source = <<~RUBY
+      class Foo
+        def bar
+          if condition
+      end
+    RUBY
+
+    diagnostics = @provider.analyze(source)
+
+    assert_equal 1, diagnostics.length
+    diagnostic = diagnostics.first
+
+    # Error should be on line 3 (0-based, parser reports line number as 0-based)
+    assert_equal 3, diagnostic[:range][:start][:line]
+  end
+
+  def test_error_line_detection_multiline
+    source = <<~RUBY
+      def method1
+        puts "ok"
+      end
+
+      def method2
+    RUBY
+
+    diagnostics = @provider.analyze(source)
+
+    assert_equal 1, diagnostics.length
+    diagnostic = diagnostics.first
+
+    # Error should be on line 4 (0-based, parser reports line number as 0-based)
+    assert_equal 4, diagnostic[:range][:start][:line]
+  end
 end


### PR DESCRIPTION
This commit resolves an issue where syntax errors were being reported one line above their actual location in the LSP diagnostics.

Changes:
- Update regex pattern to match both 'main:LINE:' and '(eval):LINE:' formats
- Remove incorrect -1 offset in line number calculation
  - Parser already returns 0-based line numbers matching LSP protocol
  - The previous -1 conversion was causing off-by-one errors
- Clean up diagnostic messages by removing redundant 'main:LINE:' prefix
- Add comprehensive test cases for error line detection across multiple scenarios

The fix ensures that when syntax errors occur, they are highlighted at the correct line in LSP-compatible editors like Vim.
