### PR TITLE
Add script_lines support for accurate LSP diagnostic ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `script_lines` support to parser for accurate line information
+  - Enable `rb_ruby_parser_set_script_lines()` in parser to capture source code lines
+  - Add `script_lines` attribute to `ParseResult` class
+  - Expose script_lines array containing each line of parsed source code
+  - Use script_lines for accurate character range calculation in LSP diagnostics
+
 ### Fixed
 - Fix LSP diagnostics to report accurate error line numbers
   - Update error message pattern matching to support both `main:LINE:` and `(eval):LINE:` formats
@@ -14,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Parser already returns 0-based line numbers, matching LSP protocol requirements
   - Clean up error messages by removing redundant `main:LINE:` prefix from diagnostic messages
   - Add comprehensive test cases for error line detection in multi-line source code
+- Fix LSP diagnostics not showing underlines in VSCode
+  - Use `script_lines` to calculate accurate line length for diagnostic range end position
+  - Set proper character range (`end.character`) to display red squiggly lines on entire error line
+  - Previously, `start` and `end` positions were identical (both at character 0), preventing underlines from appearing
 
 ## [0.5.0]
 

--- a/ext/kanayago/kanayago.c
+++ b/ext/kanayago/kanayago.c
@@ -520,6 +520,9 @@ kanayago_parse(VALUE self, VALUE source)
     // Enable error tolerant parser
     rb_ruby_parser_error_tolerant(parser_params);
 
+    // Enable script_lines to get source lines from AST
+    rb_ruby_parser_set_script_lines(parser_params);
+
     VALUE vast = rb_parser_compile_string(vparser, "main", source, 0);
 
     rb_ast_t *ast = rb_ruby_ast_data_get(vast);
@@ -528,9 +531,13 @@ kanayago_parse(VALUE self, VALUE source)
     // Get error_buffer from parser_params using accessor function
     VALUE error_buffer = rb_ruby_parser_error_buffer_get(parser_params);
 
+    // Get script_lines from AST and convert to Ruby array
+    VALUE script_lines = rb_parser_build_script_lines_from(ast->body.script_lines);
+
     VALUE result = rb_hash_new();
     rb_hash_aset(result, ID2SYM(rb_intern("ast")), ast_node);
     rb_hash_aset(result, ID2SYM(rb_intern("error")), error_buffer);
+    rb_hash_aset(result, ID2SYM(rb_intern("script_lines")), script_lines);
 
     return result;
 }

--- a/ext/kanayago/kanayago.h
+++ b/ext/kanayago/kanayago.h
@@ -13,6 +13,8 @@ VALUE rb_node_imaginary_literal_val(const NODE *);
 VALUE rb_node_str_string_val(const NODE *);
 VALUE rb_node_sym_string_val(const NODE *);
 VALUE rb_ruby_parser_error_buffer_get(rb_parser_t *);
+void rb_ruby_parser_set_script_lines(rb_parser_t *);
+VALUE rb_parser_build_script_lines_from(rb_parser_ary_t *);
 
 // Add extern for Kanayago
 extern const rb_data_type_t ruby_parser_data_type;

--- a/lib/kanayago.rb
+++ b/lib/kanayago.rb
@@ -15,11 +15,12 @@ require_relative 'kanayago/constant_node'
 # Parse Ruby code with Ruby's Parser(Universal Parser)
 module Kanayago
   class ParseResult
-    attr_reader :ast, :error
+    attr_reader :ast, :error, :script_lines
 
-    def initialize(ast, error)
+    def initialize(ast, error, script_lines)
       @ast = ast
       @error = error
+      @script_lines = script_lines
     end
 
     def invalid?
@@ -32,8 +33,8 @@ module Kanayago
   end
 
   def self.parse(source)
-    kanayago_parse(source) in { ast:, error: }
+    kanayago_parse(source) in { ast:, error:, script_lines: }
 
-    ParseResult.new(ast, error)
+    ParseResult.new(ast, error, script_lines)
   end
 end

--- a/lib/kanayago/lsp/diagnostics.rb
+++ b/lib/kanayago/lsp/diagnostics.rb
@@ -14,7 +14,7 @@ module Kanayago
         if result.invalid?
           # Extract error information from SyntaxError
           error = result.error
-          diagnostic = create_diagnostic(error)
+          diagnostic = create_diagnostic(error, result.script_lines)
           diagnostics << diagnostic
         end
 
@@ -23,11 +23,11 @@ module Kanayago
 
       private
 
-      def create_diagnostic(error)
+      def create_diagnostic(error, script_lines)
         # Try to extract line and column from error message
         # SyntaxError message format: "syntax error, unexpected ..."
         # or with location: "(eval):2: syntax error, unexpected ..."
-        range = extract_range_from_error(error)
+        range = extract_range_from_error(error, script_lines)
 
         {
           range: range,
@@ -37,22 +37,27 @@ module Kanayago
         }
       end
 
-      def extract_range_from_error(error)
+      def extract_range_from_error(error, script_lines)
         # Try to extract line number from error message
         # Format: "main:LINE: message" or "(eval):LINE: message" or just "message"
         message = error.message
 
         if message =~ /(?:main|\(eval\)):(\d+):/
           line = ::Regexp.last_match(1).to_i # Already 0-based or use as-is
+
+          end_character = script_lines[line].chomp.length
+
           {
             start: { line: line, character: 0 },
-            end: { line: line, character: 0 }
+            end: { line: line, character: end_character }
           }
         else
           # Default to line 0 if we can't extract line number
+          end_character = script_lines[0].chomp.length
+
           {
             start: { line: 0, character: 0 },
-            end: { line: 0, character: 0 }
+            end: { line: 0, character: end_character }
           }
         end
       end

--- a/test/kanayago/parse_result_test.rb
+++ b/test/kanayago/parse_result_test.rb
@@ -123,4 +123,65 @@ class ParseResultTest < Minitest::Test
     assert_predicate(result, :valid?)
     assert_instance_of(Kanayago::ScopeNode, result.ast)
   end
+
+  def test_parse_result_script_lines_with_single_line
+    result = Kanayago.parse('x = 1')
+
+    assert_instance_of(Array, result.script_lines)
+    assert_equal(['x = 1'], result.script_lines)
+  end
+
+  def test_parse_result_script_lines_with_multiple_lines
+    code = <<~RUBY
+      class Foo
+        def bar
+          puts 'hello'
+        end
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    assert_instance_of(Array, result.script_lines)
+    assert_equal(5, result.script_lines.length)
+    assert_equal("class Foo\n", result.script_lines[0])
+    assert_equal("  def bar\n", result.script_lines[1])
+    assert_equal("    puts 'hello'\n", result.script_lines[2])
+    assert_equal("  end\n", result.script_lines[3])
+    assert_equal("end\n", result.script_lines[4])
+  end
+
+  def test_parse_result_script_lines_with_syntax_error
+    code = <<~RUBY
+      def foo
+        x = 1 +
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    # script_lines should be available even with syntax errors
+    assert_instance_of(Array, result.script_lines)
+    assert_equal(3, result.script_lines.length)
+    assert_equal("def foo\n", result.script_lines[0])
+    assert_equal("  x = 1 +\n", result.script_lines[1])
+    assert_equal("end\n", result.script_lines[2])
+  end
+
+  def test_parse_result_script_lines_line_length
+    code = <<~RUBY
+      class Foo
+        def bar
+          puts 'hello world'
+        end
+      end
+    RUBY
+
+    result = Kanayago.parse(code)
+
+    # Test that we can use script_lines to get line length
+    assert_equal(9, result.script_lines[0].chomp.length) # "class Foo"
+    assert_equal(9, result.script_lines[1].chomp.length) # "  def bar"
+    assert_equal(22, result.script_lines[2].chomp.length) # "    puts 'hello world'"
+  end
 end


### PR DESCRIPTION
This commit enhances LSP diagnostics to display proper underlines in VSCode and other LSP clients by implementing script_lines support.

Changes:
- Add script_lines support to C extension
  - Call rb_ruby_parser_set_script_lines() to enable line tracking
  - Use rb_parser_build_script_lines_from() to convert to Ruby array
  - Add rb_ruby_parser_set_script_lines and rb_parser_build_script_lines_from declarations to kanayago.h
  - Return script_lines in parse result hash

- Update ParseResult class to include script_lines
  - Add script_lines attribute to ParseResult
  - Update initialize and parse methods to handle script_lines
  - script_lines contains array of source code lines from parser

- Improve LSP diagnostics range calculation
  - Use script_lines to determine accurate line length
  - Set diagnostic range end.character to actual line length
  - Enables proper red squiggly underlines in VSCode
  - Previously start and end were both at character 0, preventing underlines

- Update CHANGELOG.md with new features and fixes

The implementation ensures that syntax errors are highlighted with visible underlines across the entire error line in LSP-compatible editors like VSCode.
