### PR TITLE
Add Helix editor integration guide for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - VSCode extension: `vscode-kanayago` available on Visual Studio Marketplace
   - coc.nvim extension: `coc-kanayago` installable via `:CocInstall coc-kanayago`
   - Add screenshots and integration guides to README for both plugins
+- Add Helix editor integration guide to README
+  - Add configuration example for `~/.config/helix/languages.toml`
+  - Document how to use Kanayago LSP with Helix editor
 - Add `script_lines` support to parser for accurate line information
   - Enable `rb_ruby_parser_set_script_lines()` in parser to capture source code lines
   - Add `script_lines` attribute to `ParseResult` class

--- a/README.md
+++ b/README.md
@@ -118,6 +118,34 @@ Alternatively, you can configure the LSP server manually in your `coc-settings.j
 
 Now Vim/Neovim with coc.nvim will show syntax errors in real-time as you edit Ruby files.
 
+#### Helix Integration
+
+Add the following configuration to your `~/.config/helix/languages.toml`:
+
+```toml
+[[language]]
+name = "ruby"
+language-servers = ["kanayago"]
+
+[language-server.kanayago]
+command = "kanayago"
+args = ["--lsp"]
+```
+
+If you already have a Ruby language configuration, you can add `"kanayago"` to your existing language-servers array:
+
+```toml
+[[language]]
+name = "ruby"
+language-servers = ["kanayago", "solargraph"]  # Use alongside other LSPs
+
+[language-server.kanayago]
+command = "kanayago"
+args = ["--lsp"]
+```
+
+Now Helix will show syntax errors in real-time as you edit Ruby files.
+
 ### Command Line Interface
 
 Kanayago provides a CLI for syntax checking:


### PR DESCRIPTION
Add documentation for using Kanayago LSP with Helix editor.
Includes configuration examples for languages.toml with both standalone and multi-LSP setups.
