### PR TITLE
Add Emacs editor integration guide for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - VSCode extension: `vscode-kanayago` available on Visual Studio Marketplace
   - coc.nvim extension: `coc-kanayago` installable via `:CocInstall coc-kanayago`
   - Add screenshots and integration guides to README for both plugins
+- Add Emacs integration guide to README
+  - Add lsp-mode configuration example for `init.el`
+  - Document how to register Kanayago LSP server and enable it for Ruby files
 - Add Helix editor integration guide to README
   - Add configuration example for `~/.config/helix/languages.toml`
   - Document how to use Kanayago LSP with Helix editor

--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ Alternatively, you can configure the LSP server manually in your `coc-settings.j
 
 Now Vim/Neovim with coc.nvim will show syntax errors in real-time as you edit Ruby files.
 
+#### Emacs Integration
+
+If you're using Emacs with lsp-mode, add the following configuration to your `init.el`:
+
+```elisp
+(require 'lsp-mode)
+
+;; Register Kanayago LSP server
+(lsp-register-client
+ (make-lsp-client
+  :new-connection (lsp-stdio-connection '("kanayago" "--lsp"))
+  :major-modes '(ruby-mode enh-ruby-mode)
+  :server-id 'kanayago-lsp
+  :priority 10))
+
+;; Enable lsp-mode for Ruby files
+(add-hook 'ruby-mode-hook #'lsp-deferred)
+```
+
+Kanayago will automatically check your Ruby code for syntax errors and display diagnostics in real-time.
+
 #### Helix Integration
 
 Add the following configuration to your `~/.config/helix/languages.toml`:


### PR DESCRIPTION
Add lsp-mode configuration example to enable Kanayago LSP server in Emacs.
Users can now configure init.el to automatically check Ruby code syntax errors.
