### PR TITLE
Add Zed editor integration guide for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Helix editor integration guide to README
   - Add configuration example for `~/.config/helix/languages.toml`
   - Document how to use Kanayago LSP with Helix editor
+- Add Zed editor integration guide to README
+  - Add official Zed extension `zed-kanayago` available on Zed Extensions marketplace
+  - Document how to install and use Kanayago LSP with Zed editor
+  - Add manual installation guide for development purposes
 - Add `script_lines` support to parser for accurate line information
   - Enable `rb_ruby_parser_set_script_lines()` in parser to capture source code lines
   - Add `script_lines` attribute to `ParseResult` class

--- a/README.md
+++ b/README.md
@@ -167,6 +167,31 @@ args = ["--lsp"]
 
 Now Helix will show syntax errors in real-time as you edit Ruby files.
 
+#### Zed Integration
+
+Install the official Zed extension from the marketplace:
+
+1. Open Zed and go to Extensions (`cmd/ctrl + shift + x`)
+2. Search for "Kanayago"
+3. Click Install
+
+**Manual Installation:**
+
+If you prefer to install manually or for development purposes:
+
+```bash
+git clone https://github.com/S-H-GAMELINKS/zed-kanayago.git
+cd zed-kanayago
+```
+
+Then follow the [Zed extension development guide](https://zed.dev/docs/extensions) for installation.
+
+**Requirements:**
+- Kanayago must be installed and available in your PATH
+- Zed will automatically start the LSP server when opening Ruby files
+
+See [zed-kanayago](https://github.com/S-H-GAMELINKS/zed-kanayago) for more details.
+
 ### Command Line Interface
 
 Kanayago provides a CLI for syntax checking:


### PR DESCRIPTION
Add documentation for the official Zed extension (zed-kanayago) to `README.md` and update `CHANGELOG.md`. This follows the same pattern as previous editor integrations (VSCode, coc.nvim, Emacs, Helix).

Changes:
- Add Zed Integration section to README with installation instructions
- Include both marketplace and manual installation methods
- Add entry to CHANGELOG.md Unreleased section