### PR TITLE
Fix segfault when parsing large Ruby files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix segmentation fault when parsing large Ruby files (e.g., Rails schema.rb)
+  - Add `RB_GC_GUARD` for `vast` and `vparser` to prevent garbage collection during AST traversal
+  - The AST data is owned by `vast`, so it must remain alive until traversal is complete
+
 ## [0.6.0]
 
 ### Added

--- a/ext/kanayago/kanayago.c
+++ b/ext/kanayago/kanayago.c
@@ -528,6 +528,12 @@ kanayago_parse(VALUE self, VALUE source)
     rb_ast_t *ast = rb_ruby_ast_data_get(vast);
     VALUE ast_node = ast_to_node_instance(ast->body.root);
 
+    /* Ensure vast and vparser are not garbage collected during AST processing.
+     * The AST data (ast->body.root) is owned by vast, so we need to
+     * keep vast alive until we're done traversing the AST. */
+    RB_GC_GUARD(vast);
+    RB_GC_GUARD(vparser);
+
     // Get error_buffer from parser_params using accessor function
     VALUE error_buffer = rb_ruby_parser_error_buffer_get(parser_params);
 


### PR DESCRIPTION
Add RB_GC_GUARD for vast and vparser to prevent GC from collecting AST data during traversal.
The AST nodes are owned by vast, so it must remain alive until ast_to_node_instance completes.
