### PR TITLE
Fix support Ruby version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix support Ruby version
+  - Support Ruby 3.4 or 4.0
+
 ## [0.8.1] - 2026-03-06
 
 ### Fixed

--- a/kanayago.gemspec
+++ b/kanayago.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Trying to Make Ruby's Parser Available as a Gem"
   spec.homepage = 'https://github.com/S-H-GAMELINKS/kanayago'
   spec.license = 'MIT'
-  spec.required_ruby_version = '> 3.3.0'
+  spec.required_ruby_version = '>= 3.4.0.dev'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/S-H-GAMELINKS/kanayago'


### PR DESCRIPTION
kanayago(金屋子) supports Ruby 3.4 or 4.0
